### PR TITLE
fix: error messages, post-action descriptions, parameter metadata, template fixes

### DIFF
--- a/src/Dataverse/templates/pp-app-code-data/.template.config/template.json
+++ b/src/Dataverse/templates/pp-app-code-data/.template.config/template.json
@@ -38,7 +38,8 @@
       "args": {
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/Init.ps1\""
-      }
+      },
+      "description": "Init"
     },
     {
 			"actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",

--- a/src/Dataverse/templates/pp-app-code-data/.template.config/template.json
+++ b/src/Dataverse/templates/pp-app-code-data/.template.config/template.json
@@ -20,7 +20,8 @@
     "EntityLogicalName": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "entityexamplelogicalname"
+      "replaces": "entityexamplelogicalname",
+      "description": "Logical name of the entity including publisher prefix (e.g., udpp_warehouseitem)"
     },
     "SolutionRootPath": {
 			"type": "parameter",

--- a/src/Dataverse/templates/pp-app-code/CodeAppExample.csproj
+++ b/src/Dataverse/templates/pp-app-code/CodeAppExample.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.15">
+<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.16">
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <AppName>codeappexample</AppName>

--- a/src/Dataverse/templates/pp-app-model-component/.template.config/template.json
+++ b/src/Dataverse/templates/pp-app-model-component/.template.config/template.json
@@ -120,7 +120,8 @@
         {
           "text": "Adding Model Driven App to solution xml"
         }
-      ]
+      ],
+      "description": "Add component to model driven app"
     },
     {
 			"actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",

--- a/src/Dataverse/templates/pp-app-model-component/.template.config/template.json
+++ b/src/Dataverse/templates/pp-app-model-component/.template.config/template.json
@@ -15,7 +15,8 @@
     "AppName": {
       "type": "parameter",
       "datatype": "text",
-      "description": "Name of the model-driven app where the component will be added",
+      "description": "Name of the model-driven app including publisher prefix (e.g., udpp_warehouseapp)",
+      "isRequired": true,
       "replaces": "appexamplename",
       "fileRename": "appexamplename"
     },
@@ -81,7 +82,7 @@
     "EntityLogicalName": {
       "type": "parameter",
       "datatype": "text",
-      "description": "Logical name of the entity for the component (Example: account, contact, custom_entity)",
+      "description": "Logical name of the entity including publisher prefix (e.g., udpp_warehouseitem)",
       "replaces": "entityexamplename"
     },
     "ComponentId": {

--- a/src/Dataverse/templates/pp-app-model/.template.config/template.json
+++ b/src/Dataverse/templates/pp-app-model/.template.config/template.json
@@ -16,13 +16,15 @@
       "type": "parameter",
       "datatype": "text",
       "description": "Publisher prefix for the app (Example: new, talxis) - used in naming conventions",
+      "isRequired": true,
       "replaces": "userprefixexample",
       "fileRename": "userprefixexample"
     },
     "LogicalName": {
       "type": "parameter",
       "datatype": "text",
-      "description": "Logical name of the model-driven app (Example: customapp, salesapp)",
+      "description": "Logical name of the app without publisher prefix (e.g., warehouseapp). The prefix is added automatically.",
+      "isRequired": true,
       "replaces": "appexamplename",
       "fileRename": "appexamplename"
     },

--- a/src/Dataverse/templates/pp-app-model/.template.config/template.json
+++ b/src/Dataverse/templates/pp-app-model/.template.config/template.json
@@ -56,7 +56,8 @@
         {
           "text": "Adding Model Driven App to solution xml"
         }
-      ]
+      ],
+      "description": "Add model driven app to solution XML"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -68,7 +69,8 @@
         {
           "text": "Adding Model Driven App to solution xml"
         }
-      ]
+      ],
+      "description": "Generate ID for app module site map"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -80,7 +82,8 @@
         {
           "text": "Adding sitemapp  to solution xml"
         }
-      ]
+      ],
+      "description": "Add site map to solution XML"
     },{
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
       "args": {
@@ -91,7 +94,8 @@
         {
           "text": "Adding SiteMap to Customizations xml"
         }
-      ]
+      ],
+      "description": "Add site map to customizations XML"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -103,7 +107,8 @@
         {
           "text": "Adding Model Driven App to Customizations xml"
         }
-      ]
+      ],
+      "description": "Add model driven app to customizations XML"
     },
     {
 			"actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",

--- a/src/Dataverse/templates/pp-bpf-stage-step/.template.config/template.json
+++ b/src/Dataverse/templates/pp-bpf-stage-step/.template.config/template.json
@@ -189,7 +189,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/AddToXaml.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Add to XAML"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -197,7 +198,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/AddStepToForm.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Add step to form"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -205,7 +207,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/steplabels.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Step labels"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -213,7 +216,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/RestoreXaml.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Restore XAML"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",

--- a/src/Dataverse/templates/pp-bpf-stage-step/.template.scripts/AddToXaml.ps1
+++ b/src/Dataverse/templates/pp-bpf-stage-step/.template.scripts/AddToXaml.ps1
@@ -4,6 +4,7 @@ $stepXamlPath = (Resolve-Path '.template.temp\step.xaml').Path
 $targetXamlFile = Get-ChildItem -Path $targetXamlFolderPath -Recurse -Filter *.xaml | Select-Object -First 1
 
 if (-not $targetXamlFile) {
+    Write-Error "Could not find a .xaml file in $targetXamlFolderPath."
     exit 1
 }
 

--- a/src/Dataverse/templates/pp-bpf-stage-step/.template.scripts/steplabels.ps1
+++ b/src/Dataverse/templates/pp-bpf-stage-step/.template.scripts/steplabels.ps1
@@ -4,6 +4,7 @@ $steplabelsPath = (Resolve-Path '.template.temp\steplabels.xml').Path
 $targetXmlFile = Get-ChildItem -Path $targetXmlFolderPath -Recurse -Filter *.xml | Select-Object -First 1
 
 if (-not $targetXmlFile) {
+    Write-Error "Could not find a .xml file in $targetXmlFolderPath."
     exit 1
 }
 

--- a/src/Dataverse/templates/pp-bpf-stage/.template.config/template.json
+++ b/src/Dataverse/templates/pp-bpf-stage/.template.config/template.json
@@ -112,7 +112,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/NextStage.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Next stage"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -120,7 +121,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/AddToXaml.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Add to XAML"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -128,7 +130,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/AddToForm.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Add to form"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -136,7 +139,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/steplabels.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Step labels"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",

--- a/src/Dataverse/templates/pp-bpf-stage/.template.scripts/AddToForm.ps1
+++ b/src/Dataverse/templates/pp-bpf-stage/.template.scripts/AddToForm.ps1
@@ -7,6 +7,7 @@ $stageFormPath = (Resolve-Path '.template.temp\stageForm.xml').Path
 $tabsNode = $targetXml.SelectSingleNode('//tabs')
 
 if (-not $tabsNode) {
+    Write-Error "Could not find tabs node in the target form XML."
     exit 1
 }
 

--- a/src/Dataverse/templates/pp-bpf-stage/.template.scripts/AddToXaml.ps1
+++ b/src/Dataverse/templates/pp-bpf-stage/.template.scripts/AddToXaml.ps1
@@ -4,6 +4,7 @@ $stageXamlPath = (Resolve-Path '.template.temp\stage.xaml').Path
 $targetXamlFile = Get-ChildItem -Path $targetXamlFolderPath -Recurse -Filter *.xaml | Select-Object -First 1
 
 if (-not $targetXamlFile) {
+    Write-Error "Could not find a .xaml file in $targetXamlFolderPath."
     exit 1
 }
 

--- a/src/Dataverse/templates/pp-bpf-stage/.template.scripts/steplabels.ps1
+++ b/src/Dataverse/templates/pp-bpf-stage/.template.scripts/steplabels.ps1
@@ -4,6 +4,7 @@ $steplabelsPath = (Resolve-Path '.template.temp\steplabels.xml').Path
 $targetXmlFile = Get-ChildItem -Path $targetXmlFolderPath -Recurse -Filter *.xml | Select-Object -First 1
 
 if (-not $targetXmlFile) {
+    Write-Error "Could not find a .xml file in $targetXmlFolderPath."
     exit 1
 }
 

--- a/src/Dataverse/templates/pp-bpf/.template.config/template.json
+++ b/src/Dataverse/templates/pp-bpf/.template.config/template.json
@@ -76,7 +76,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/GenerateWorkflowId.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Generate workflow ID"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -84,7 +85,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/AddRelationshipsl.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Add relationships"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -92,7 +94,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/AddToSolutionXml.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Add to solution XML"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",

--- a/src/Dataverse/templates/pp-control-parameter/.template.config/template.json
+++ b/src/Dataverse/templates/pp-control-parameter/.template.config/template.json
@@ -180,7 +180,7 @@
       "isRequired": false,
       "defaultValue": "defaultеtemplateexample",
       "replaces": "entitylogicalnameexampletypestring",
-      "description": "Logical name of the entity that the lookup refers to. (This parameter is applicable in bound and unbound lookups)"
+      "description": "Logical name of the entity including publisher prefix (e.g., udpp_warehouseitem)"
     },
     "DefaultViewId": {
       "type": "parameter",

--- a/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
@@ -42,7 +42,7 @@
       "fileRename": "exampleexistingentity",
       "replaces": "exampleexistingentity",
       "isRequired": true,
-      "description": "Typically, a Pascal cased version of the logical name. For example, Account"
+      "description": "Schema name of the entity including publisher prefix (e.g., udpp_warehouseitem)"
     },
     "AttributeType": {
       "type": "parameter",
@@ -94,7 +94,7 @@
     },
     "LogicalName": {
       "displayName": "Logical name (without publisher prefix)",
-      "description": "All lower-case version of the schema name. For example, account",
+      "description": "Logical name of the attribute without publisher prefix (e.g., availablequantity). The prefix is added automatically.",
       "type": "parameter",
       "datatype": "text",
       "replaces": "examplecustomentityattribute",
@@ -155,7 +155,7 @@
       "datatype": "text",
       "replaces": "examplereferencedentityname",
       "isRequired": "AttributeType == \"Lookup\"",
-      "description": "Logical name of the entity that the lookup attribute will reference (required for Lookup type)"
+      "description": "Logical name of the referenced entity including publisher prefix (e.g., udpp_warehouseitem)"
     },
     "AddLookupRelationship": {
       "type": "computed",

--- a/src/Dataverse/templates/pp-entity-form/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-form/.template.config/template.json
@@ -68,10 +68,11 @@
 		"EntitySchemaName": {
 			"type": "parameter",
 			"datatype": "text",
-			"defaultValue": ".",
+			"defaultValue": "exampleentity",
+			"isRequired": true,
 			"replaces": "ItemFolderName",
 			"fileRename": "ItemFolderName",
-			"description": "Logical name of the entity for which the form will be created"
+			"description": "Schema name of the entity including publisher prefix (e.g., udpp_warehouseitem)"
 		},
 		"DialogUniqueName": {
 			"type": "parameter",

--- a/src/Dataverse/templates/pp-entity-view/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-view/.template.config/template.json
@@ -33,7 +33,7 @@
       "isRequired": true,
       "replaces": "exampleexistingentity",
       "fileRename": "exampleexistingentity",
-      "description": "Schema name of the entity including publisher prefix (Example: new_customentity)"
+      "description": "Schema name of the entity including publisher prefix (e.g., udpp_warehouseitem)"
     },
     "PublisherPrefix": {
       "type": "parameter",

--- a/src/Dataverse/templates/pp-entity/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity/.template.config/template.json
@@ -163,7 +163,7 @@
 		},
 		"LogicalName": {
 			"displayName": "Logical name (without publisher prefix)",
-			"description": "All lower-case version of the schema name. For example, salesorder",
+			"description": "Logical name without publisher prefix (e.g., warehouseitem). The prefix is added automatically.",
 			"type": "parameter",
 			"datatype": "text",
 			"replaces": "examplecustomentity",

--- a/src/Dataverse/templates/pp-form-cell/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-cell/.template.config/template.json
@@ -18,7 +18,7 @@
       "replaces": "exampleentityname",
       "isRequired": false,
       "defaultValue": "unknown",
-      "description": "Logical name of the entity for which the cell will be created"
+      "description": "Schema name of the entity including publisher prefix (e.g., udpp_warehouseitem)"
     },
     "SolutionRootPath": {
       "type": "parameter",

--- a/src/Dataverse/templates/pp-form-column/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-column/.template.config/template.json
@@ -18,7 +18,7 @@
       "replaces": "exampleentityname",
       "isRequired": false,
       "defaultValue": "unknown",
-      "description": "Logical name of the entity for which the column will be created"
+      "description": "Schema name of the entity including publisher prefix (e.g., udpp_warehouseitem)"
     },
     "SolutionRootPath": {
       "type": "parameter",

--- a/src/Dataverse/templates/pp-form-control/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-control/.template.config/template.json
@@ -18,7 +18,7 @@
       "replaces": "exampleentityname",
       "isRequired": false,
       "defaultValue": "unknown",
-      "description": "Logical name of the entity for which the control will be created"
+      "description": "Schema name of the entity including publisher prefix (e.g., udpp_warehouseitem)"
     },
     "SolutionRootPath": {
       "type": "parameter",

--- a/src/Dataverse/templates/pp-form-parameter/.template.scripts/Add.ps1
+++ b/src/Dataverse/templates/pp-form-parameter/.template.scripts/Add.ps1
@@ -6,6 +6,7 @@ $paramType = "typeexample"
 
 $formNode = $entityXml.SelectSingleNode('//form')
 if (-not $formNode) {
+    Write-Error "Could not find form node in the XML file."
     exit 1
 }
 

--- a/src/Dataverse/templates/pp-form-row/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-row/.template.config/template.json
@@ -18,7 +18,7 @@
       "replaces": "exampleentityname",
       "isRequired": false,
       "defaultValue": "unknown",
-      "description": "Logical name of the entity for which the row will be created"
+      "description": "Schema name of the entity including publisher prefix (e.g., udpp_warehouseitem)"
     },
     "SolutionRootPath": {
       "type": "parameter",

--- a/src/Dataverse/templates/pp-form-section/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-section/.template.config/template.json
@@ -18,7 +18,7 @@
       "replaces": "exampleentityname",
       "isRequired": false,
       "defaultValue": "unknown",
-      "description": "Logical name of the entity for which the section will be created"
+      "description": "Schema name of the entity including publisher prefix (e.g., udpp_warehouseitem)"
     },
     "SolutionRootPath": {
       "type": "parameter",

--- a/src/Dataverse/templates/pp-form-subgrid/.template.scripts/add.ps1
+++ b/src/Dataverse/templates/pp-form-subgrid/.template.scripts/add.ps1
@@ -5,6 +5,7 @@ $rowPath = (Resolve-Path './.template.temp/subgrid.xml').Path
 
 $rowsNode = $entityXml.SelectSingleNode('//rows')
 if (-not $rowsNode) {
+    Write-Error "Could not find rows node in the XML file."
     exit 1
 }
 

--- a/src/Dataverse/templates/pp-form-tab/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-tab/.template.config/template.json
@@ -18,7 +18,7 @@
       "replaces": "exampleentityname",
       "isRequired": false,
       "defaultValue": "unknown",
-      "description": "Logical name of the entity for which the tab will be created"
+      "description": "Schema name of the entity including publisher prefix (e.g., udpp_warehouseitem)"
     },
     "SolutionRootPath": {
       "type": "parameter",

--- a/src/Dataverse/templates/pp-form-tab/.template.scripts/Add.ps1
+++ b/src/Dataverse/templates/pp-form-tab/.template.scripts/Add.ps1
@@ -6,6 +6,7 @@ $tabPath = (Resolve-Path './.template.temp/tab.xml').Path
 
 $tabsNode = $entityXml.SelectSingleNode('//tabs')
 if (-not $tabsNode) {
+    Write-Error "Could not find tabs node in the XML file."
     exit 1
 }
 

--- a/src/Dataverse/templates/pp-optionset-global/.template.config/template.json
+++ b/src/Dataverse/templates/pp-optionset-global/.template.config/template.json
@@ -46,7 +46,7 @@
       "replaces": "examplecustomentityattribute",
       "fileRename": "examplecustomentityattribute",
       "isRequired": true,
-      "description": "Logical name of the option set (Example: new_status, new_priority)"
+      "description": "Logical name of the option set without publisher prefix (e.g., paymentmethod). The prefix is added automatically."
     },
     "DisplayName": {
       "type": "parameter",

--- a/src/Dataverse/templates/pp-package/.template.config/template.json
+++ b/src/Dataverse/templates/pp-package/.template.config/template.json
@@ -22,7 +22,8 @@
         {
           "text": "Creating Package"
         }
-      ]
+      ],
+      "description": "Create package"
     },
     {
 			"actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",

--- a/src/Dataverse/templates/pp-package/pdpackageexamplename.csproj
+++ b/src/Dataverse/templates/pp-package/pdpackageexamplename.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.15">
+<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.16">
   <PropertyGroup>
     <ProjectType>PDPackage</ProjectType>
     <TargetFramework>net472</TargetFramework>

--- a/src/Dataverse/templates/pp-pcf/examplesourcename.csproj
+++ b/src/Dataverse/templates/pp-pcf/examplesourcename.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.15">
+<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.16">
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <Name>examplesourcename</Name>

--- a/src/Dataverse/templates/pp-plugin-assembly-step/.template.config/template.json
+++ b/src/Dataverse/templates/pp-plugin-assembly-step/.template.config/template.json
@@ -195,42 +195,48 @@
       "args": {
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/AddFilteringAttributes.ps1\" "
-      }
+      },
+      "description": "Add filtering attributes"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
       "args": {
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/AddPluginSolutionXml.ps1\" "
-      }
+      },
+      "description": "Add plugin solution XML"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
       "args": {
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/AddPublicKey.ps1\" "
-      }
+      },
+      "description": "Add public key"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
       "args": {
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/SetPluginTypeId.ps1\" "
-      }
+      },
+      "description": "Set plugin type ID"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
       "args": {
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/CopyStep.ps1\" "
-      }
+      },
+      "description": "Copy step"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
       "args": {
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/AddPluginStepCustomizationsXml.ps1\" "
-      }
+      },
+      "description": "Add plugin step customizations XML"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",

--- a/src/Dataverse/templates/pp-plugin-assembly/.template.config/template.json
+++ b/src/Dataverse/templates/pp-plugin-assembly/.template.config/template.json
@@ -38,21 +38,24 @@
       "args": {
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/GenerateAssembly.ps1\" "
-      }
+      },
+      "description": "Generate assembly"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
       "args": {
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/AddAssemblyToSolution.ps1\" "
-      }
+      },
+      "description": "Add assembly to solution"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
       "args": {
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/AddPluginAssemblyCustomizationsXml.ps1\" "
-      }
+      },
+      "description": "Add plugin assembly customizations XML"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",

--- a/src/Dataverse/templates/pp-plugin-test/.template.config/template.json
+++ b/src/Dataverse/templates/pp-plugin-test/.template.config/template.json
@@ -18,7 +18,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/SetUp.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Set up"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -26,7 +27,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/Cleanup.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Cleanup"
     }
   ]
 }

--- a/src/Dataverse/templates/pp-plugin/.template.scripts/InitializePlugin.ps1
+++ b/src/Dataverse/templates/pp-plugin/.template.scripts/InitializePlugin.ps1
@@ -13,6 +13,7 @@ Remove-Item .\Plugin1.cs -ErrorAction SilentlyContinue
 # --- 3. Find the .csproj file ---
 $csprojFile = Get-ChildItem -Path . -Filter *.csproj | Select-Object -First 1
 if (-not $csprojFile) {
+    Write-Error "Could not find a .csproj file in the current directory."
     exit 1
 }
 

--- a/src/Dataverse/templates/pp-plugin/SolutionLogicalNameExample.csproj
+++ b/src/Dataverse/templates/pp-plugin/SolutionLogicalNameExample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.15">
+<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.16">
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <SignAssembly>true</SignAssembly>

--- a/src/Dataverse/templates/pp-ribbon-button-hide/.template.config/template.json
+++ b/src/Dataverse/templates/pp-ribbon-button-hide/.template.config/template.json
@@ -47,7 +47,7 @@
       "replaces": "exampleentityname",
       "fileRename": "exampleentityname",
       "isRequired": true,
-      "description": "Logical name of the entity where the ribbon button will be added"
+      "description": "Logical name of the entity including publisher prefix (e.g., udpp_warehouseitem)"
     },
     "ButtonToHide": {
 			"type": "parameter",

--- a/src/Dataverse/templates/pp-ribbon-button-hide/.template.config/template.json
+++ b/src/Dataverse/templates/pp-ribbon-button-hide/.template.config/template.json
@@ -68,7 +68,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/Hide.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Hide"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -76,7 +77,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/Cleanup.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Cleanup"
     }
   ]
 }

--- a/src/Dataverse/templates/pp-ribbon-button/.template.config/template.json
+++ b/src/Dataverse/templates/pp-ribbon-button/.template.config/template.json
@@ -147,7 +147,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/SetIcon.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Set icon"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -155,7 +156,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/SetButtonLogicalName.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Set button logical name"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -163,7 +165,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/RibbonDiff.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Ribbon diff"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -171,7 +174,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/Cleanup.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Cleanup"
     }
   ]
 }

--- a/src/Dataverse/templates/pp-ribbon-button/.template.config/template.json
+++ b/src/Dataverse/templates/pp-ribbon-button/.template.config/template.json
@@ -55,7 +55,7 @@
       "replaces": "exampleentityname",
       "fileRename": "exampleentityname",
       "isRequired": true,
-      "description": "Logical name of the entity where the ribbon button will be added"
+      "description": "Logical name of the entity including publisher prefix (e.g., udpp_warehouseitem)"
     },
     "Image32by32": {
       "type": "parameter",

--- a/src/Dataverse/templates/pp-ribbon-command-parameter/.template.config/template.json
+++ b/src/Dataverse/templates/pp-ribbon-command-parameter/.template.config/template.json
@@ -98,7 +98,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/SetParameter.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Set parameter"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -106,7 +107,8 @@
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/Cleanup.ps1\"",
         "redirectStandardOutput": "false"
-      }
+      },
+      "description": "Cleanup"
     }
   ]
 }

--- a/src/Dataverse/templates/pp-ribbon-command-parameter/.template.config/template.json
+++ b/src/Dataverse/templates/pp-ribbon-command-parameter/.template.config/template.json
@@ -47,7 +47,7 @@
       "replaces": "exampleentityname",
       "fileRename": "exampleentityname",
       "isRequired": true,
-      "description": "Logical name of the entity where the ribbon button will be added"
+      "description": "Logical name of the entity including publisher prefix (e.g., udpp_warehouseitem)"
     },
     "ParameterInput": {
       "type": "parameter",

--- a/src/Dataverse/templates/pp-script-library/examplesourcename.csproj
+++ b/src/Dataverse/templates/pp-script-library/examplesourcename.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.15">
+<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.16">
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <ProjectType>ScriptLibrary</ProjectType>

--- a/src/Dataverse/templates/pp-security-role-privilege/.template.config/template.json
+++ b/src/Dataverse/templates/pp-security-role-privilege/.template.config/template.json
@@ -25,7 +25,7 @@
 			"datatype": "text",
 			"defaultValue": ".",
       "replaces": "entityexamplename",
-			"description": "Logical name of the entity for which privileges will be created"
+			"description": "Logical name of the entity including publisher prefix (e.g., udpp_warehouseitem)"
     },
     "RoleName": {
       "type": "parameter",

--- a/src/Dataverse/templates/pp-security-role-privilege/.template.scripts/AddPrivilegesToSecurityRole.ps1
+++ b/src/Dataverse/templates/pp-security-role-privilege/.template.scripts/AddPrivilegesToSecurityRole.ps1
@@ -5,6 +5,7 @@ $privilegesPath = (Resolve-Path '.template.scripts/privileges.xml').Path
 
 $rolePrivilegesNode = $entityXml.SelectSingleNode('//Role/RolePrivileges')
 if (-not $rolePrivilegesNode) {
+    Write-Error "Could not find Role/RolePrivileges node in the XML file."
     exit 1
 }
 

--- a/src/Dataverse/templates/pp-security-role/.template.config/template.json
+++ b/src/Dataverse/templates/pp-security-role/.template.config/template.json
@@ -59,7 +59,8 @@
         {
           "text": "Adding Security Role to solution xml"
         }
-      ]
+      ],
+      "description": "Add security role to solution"
     },
     {
 			"actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",

--- a/src/Dataverse/templates/pp-sitemap-area/.template.config/template.json
+++ b/src/Dataverse/templates/pp-sitemap-area/.template.config/template.json
@@ -23,7 +23,8 @@
     "AppName": {
       "type": "parameter",
       "datatype": "text",
-      "description": "Name of the app module where the sitemap will be modified",
+      "description": "Name of the app module including publisher prefix (e.g., udpp_warehouseapp)",
+      "isRequired": true,
       "replaces": "appexamplename",
       "fileRename": "appexamplename"
     },

--- a/src/Dataverse/templates/pp-sitemap-area/.template.config/template.json
+++ b/src/Dataverse/templates/pp-sitemap-area/.template.config/template.json
@@ -56,7 +56,9 @@
         {
           "text": "Adding Model Driven App to solution xml"
         }
-      ]
+      ],
+      "continueOnError": false,
+      "description": "Generate unique ID for sitemap area"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -66,9 +68,11 @@
       },
       "manualInstructions": [
         {
-          "text": "Adding area to the sitemapp "
+          "text": "Adding area to the sitemap"
         }
-      ]
+      ],
+      "continueOnError": false,
+      "description": "Add area to sitemap XML"
     },
     {
 			"actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",

--- a/src/Dataverse/templates/pp-sitemap-area/.template.scripts/AddAreaToSitemap.ps1
+++ b/src/Dataverse/templates/pp-sitemap-area/.template.scripts/AddAreaToSitemap.ps1
@@ -13,6 +13,7 @@ foreach ($candidatePath in $entityXmlRelativePaths) {
 }
 
 if (-not $entityXmlPath) {
+    Write-Error "Could not find AppModuleSiteMap XML file. Searched paths: $($entityXmlRelativePaths -join ', ')"
     exit 1
 }
 
@@ -23,6 +24,7 @@ $areaPath  = (Resolve-Path '.template.temp/area.xml').Path
 
 $siteMapNode = $entityXml.SelectSingleNode('//SiteMap')
 if (-not $siteMapNode) {
+    Write-Error "Could not find SiteMap node in $entityXmlPath"
     exit 1
 }
 

--- a/src/Dataverse/templates/pp-sitemap-group/.template.config/template.json
+++ b/src/Dataverse/templates/pp-sitemap-group/.template.config/template.json
@@ -23,7 +23,8 @@
     "AppName": {
       "type": "parameter",
       "datatype": "text",
-      "description": "Name of the app module where the sitemap will be modified",
+      "description": "Name of the app module including publisher prefix (e.g., udpp_warehouseapp)",
+      "isRequired": true,
       "replaces": "appexamplename",
       "fileRename": "appexamplename"
     },
@@ -47,6 +48,7 @@
       "type": "parameter",
       "datatype": "text",
       "description": "Title of the area in the sitemap where the group will be added",
+      "isRequired": true,
       "defaultValue": "NewTitle",
       "replaces": "areatitleexample",
       "fileRename": "areatitleexample"

--- a/src/Dataverse/templates/pp-sitemap-group/.template.config/template.json
+++ b/src/Dataverse/templates/pp-sitemap-group/.template.config/template.json
@@ -72,7 +72,8 @@
         {
           "text": "Adding Model Driven App to solution xml"
         }
-      ]
+      ],
+      "description": "Generate ID for app module site map"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -84,7 +85,8 @@
         {
           "text": "Adding area to the sitemapp "
         }
-      ]
+      ],
+      "description": "Add group to area"
     },
     {
 			"actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",

--- a/src/Dataverse/templates/pp-sitemap-group/.template.scripts/AddGroupToArea.ps1
+++ b/src/Dataverse/templates/pp-sitemap-group/.template.scripts/AddGroupToArea.ps1
@@ -13,6 +13,7 @@ foreach ($candidatePath in $entityXmlRelativePaths) {
 }
 
 if (-not $entityXmlPath) {
+    Write-Error "Could not find the SiteMap XML file. Check that the file exists and the path parameters are correct."
     exit 1
 }
 
@@ -25,6 +26,7 @@ $groupPath = (Resolve-Path '.template.temp/group.xml').Path
 $areaNode = $entityXml.SelectSingleNode("//SiteMap/Area[@ResourceId='SitemapDesigner.areatitleexample']")
 
 if (-not $areaNode) {
+    Write-Error "Could not find the Area node in the SiteMap XML."
     exit 1
 }
 

--- a/src/Dataverse/templates/pp-sitemap-subarea/.template.config/template.json
+++ b/src/Dataverse/templates/pp-sitemap-subarea/.template.config/template.json
@@ -70,7 +70,8 @@
         {
           "text": "Adding Model Driven App to solution xml"
         }
-      ]
+      ],
+      "description": "Generate ID for app module site map"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -82,7 +83,8 @@
         {
           "text": "Adding area to the sitemapp "
         }
-      ]
+      ],
+      "description": "Add sub area to group"
     },
     {
 			"actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",

--- a/src/Dataverse/templates/pp-sitemap-subarea/.template.config/template.json
+++ b/src/Dataverse/templates/pp-sitemap-subarea/.template.config/template.json
@@ -15,7 +15,8 @@
     "EntityLogicalName": {
       "type": "parameter",
       "datatype": "text",
-      "description": "Logical name of the entity that the subarea will navigate to",
+      "description": "Logical name of the entity including publisher prefix (e.g., udpp_warehouseitem)",
+      "isRequired": true,
       "replaces": "entityexamplename"
     },
     "SolutionRootPath": {
@@ -30,6 +31,7 @@
       "type": "parameter",
       "datatype": "text",
       "description": "Title of the group in the sitemap where the subarea will be added",
+      "isRequired": true,
       "defaultValue": "NewTitle",
       "replaces": "grouptitleexample",
       "fileRename": "grouptitleexample"
@@ -38,6 +40,7 @@
       "type": "parameter",
       "datatype": "text",
       "description": "Title of the area in the sitemap where the subarea will be added",
+      "isRequired": true,
       "defaultValue": "NewTitle",
       "replaces": "areatitleexample",
       "fileRename": "areatitleexample"
@@ -45,7 +48,8 @@
     "AppName": {
       "type": "parameter",
       "datatype": "text",
-      "description": "Name of the app module where the sitemap will be modified",
+      "description": "Name of the app module including publisher prefix (e.g., udpp_warehouseapp)",
+      "isRequired": true,
       "replaces": "appexamplename",
       "fileRename": "appexamplename"
     }

--- a/src/Dataverse/templates/pp-sitemap-subarea/.template.scripts/AddSubAreaToGroup.ps1
+++ b/src/Dataverse/templates/pp-sitemap-subarea/.template.scripts/AddSubAreaToGroup.ps1
@@ -13,6 +13,7 @@ foreach ($candidatePath in $entityXmlRelativePaths) {
 }
 
 if (-not $entityXmlPath) {
+    Write-Error "Could not find the SiteMap XML file. Check that the file exists and the path parameters are correct."
     exit 1
 }
 
@@ -24,6 +25,7 @@ $subareaPath = (Resolve-Path '.template.temp/subarea.xml').Path
 $groupNode = $entityXml.SelectSingleNode("//SiteMap/Area[@ResourceId='SitemapDesigner.areatitleexample']/Group[@ResourceId='SitemapDesigner.grouptitleexample']")
 
 if (-not $groupNode) {
+    Write-Error "Could not find the Group node in the SiteMap XML."
     exit 1
 }
 

--- a/src/Dataverse/templates/pp-solution/.template.scripts/FlattenSolutionRootIfInplace.ps1
+++ b/src/Dataverse/templates/pp-solution/.template.scripts/FlattenSolutionRootIfInplace.ps1
@@ -5,7 +5,9 @@ if ($solutionRootPath -ne ".") { return }
 $projectRoot = (Get-Location).Path
 
 $stranded = Join-Path $projectRoot "SolutionDeclarationsRoot"
-if (Test-Path -LiteralPath $stranded) {
+$strandedResolved = (Resolve-Path -LiteralPath $stranded -ErrorAction SilentlyContinue)?.Path
+# Skip if the stranded path resolves to the project root itself (SolutionRootPath was '.')
+if ($strandedResolved -and $strandedResolved -ne $projectRoot -and (Test-Path -LiteralPath $stranded)) {
     Get-ChildItem -LiteralPath $stranded -Force | ForEach-Object {
         Move-Item -LiteralPath $_.FullName -Destination $projectRoot -Force
     }

--- a/src/Dataverse/templates/pp-solution/SolutionDeclarationsRoot/Other/Solution.xml
+++ b/src/Dataverse/templates/pp-solution/SolutionDeclarationsRoot/Other/Solution.xml
@@ -22,8 +22,8 @@
         <!-- Description of Cds Publisher in language code -->
         <Description description="examplepublisher" languagecode="1033" />
       </Descriptions>
-      <EMailAddress xsi:nil="true"></EMailAddress>
-      <SupportingWebsiteUrl xsi:nil="true"></SupportingWebsiteUrl>
+      <EMailAddress xsi:nil="true" />
+      <SupportingWebsiteUrl xsi:nil="true" />
       <!-- Customization Prefix for the Cds Publisher-->
       <CustomizationPrefix>examplepublisherprefix</CustomizationPrefix>
       <!-- Derived Option Value Prefix for the Customization Prefix of Cds Publisher -->
@@ -33,58 +33,58 @@
         <Address>
           <AddressNumber>1</AddressNumber>
           <AddressTypeCode>1</AddressTypeCode>
-          <City xsi:nil="true"></City>
-          <County xsi:nil="true"></County>
-          <Country xsi:nil="true"></Country>
-          <Fax xsi:nil="true"></Fax>
-          <FreightTermsCode xsi:nil="true"></FreightTermsCode>
-          <ImportSequenceNumber xsi:nil="true"></ImportSequenceNumber>
-          <Latitude xsi:nil="true"></Latitude>
-          <Line1 xsi:nil="true"></Line1>
-          <Line2 xsi:nil="true"></Line2>
-          <Line3 xsi:nil="true"></Line3>
-          <Longitude xsi:nil="true"></Longitude>
-          <Name xsi:nil="true"></Name>
-          <PostalCode xsi:nil="true"></PostalCode>
-          <PostOfficeBox xsi:nil="true"></PostOfficeBox>
-          <PrimaryContactName xsi:nil="true"></PrimaryContactName>
+          <City xsi:nil="true" />
+          <County xsi:nil="true" />
+          <Country xsi:nil="true" />
+          <Fax xsi:nil="true" />
+          <FreightTermsCode xsi:nil="true" />
+          <ImportSequenceNumber xsi:nil="true" />
+          <Latitude xsi:nil="true" />
+          <Line1 xsi:nil="true" />
+          <Line2 xsi:nil="true" />
+          <Line3 xsi:nil="true" />
+          <Longitude xsi:nil="true" />
+          <Name xsi:nil="true" />
+          <PostalCode xsi:nil="true" />
+          <PostOfficeBox xsi:nil="true" />
+          <PrimaryContactName xsi:nil="true" />
           <ShippingMethodCode>1</ShippingMethodCode>
-          <StateOrProvince xsi:nil="true"></StateOrProvince>
-          <Telephone1 xsi:nil="true"></Telephone1>
-          <Telephone2 xsi:nil="true"></Telephone2>
-          <Telephone3 xsi:nil="true"></Telephone3>
-          <TimeZoneRuleVersionNumber xsi:nil="true"></TimeZoneRuleVersionNumber>
-          <UPSZone xsi:nil="true"></UPSZone>
-          <UTCOffset xsi:nil="true"></UTCOffset>
-          <UTCConversionTimeZoneCode xsi:nil="true"></UTCConversionTimeZoneCode>
+          <StateOrProvince xsi:nil="true" />
+          <Telephone1 xsi:nil="true" />
+          <Telephone2 xsi:nil="true" />
+          <Telephone3 xsi:nil="true" />
+          <TimeZoneRuleVersionNumber xsi:nil="true" />
+          <UPSZone xsi:nil="true" />
+          <UTCOffset xsi:nil="true" />
+          <UTCConversionTimeZoneCode xsi:nil="true" />
         </Address>
         <Address>
           <AddressNumber>2</AddressNumber>
           <AddressTypeCode>1</AddressTypeCode>
-          <City xsi:nil="true"></City>
-          <County xsi:nil="true"></County>
-          <Country xsi:nil="true"></Country>
-          <Fax xsi:nil="true"></Fax>
-          <FreightTermsCode xsi:nil="true"></FreightTermsCode>
-          <ImportSequenceNumber xsi:nil="true"></ImportSequenceNumber>
-          <Latitude xsi:nil="true"></Latitude>
-          <Line1 xsi:nil="true"></Line1>
-          <Line2 xsi:nil="true"></Line2>
-          <Line3 xsi:nil="true"></Line3>
-          <Longitude xsi:nil="true"></Longitude>
-          <Name xsi:nil="true"></Name>
-          <PostalCode xsi:nil="true"></PostalCode>
-          <PostOfficeBox xsi:nil="true"></PostOfficeBox>
-          <PrimaryContactName xsi:nil="true"></PrimaryContactName>
+          <City xsi:nil="true" />
+          <County xsi:nil="true" />
+          <Country xsi:nil="true" />
+          <Fax xsi:nil="true" />
+          <FreightTermsCode xsi:nil="true" />
+          <ImportSequenceNumber xsi:nil="true" />
+          <Latitude xsi:nil="true" />
+          <Line1 xsi:nil="true" />
+          <Line2 xsi:nil="true" />
+          <Line3 xsi:nil="true" />
+          <Longitude xsi:nil="true" />
+          <Name xsi:nil="true" />
+          <PostalCode xsi:nil="true" />
+          <PostOfficeBox xsi:nil="true" />
+          <PrimaryContactName xsi:nil="true" />
           <ShippingMethodCode>1</ShippingMethodCode>
-          <StateOrProvince xsi:nil="true"></StateOrProvince>
-          <Telephone1 xsi:nil="true"></Telephone1>
-          <Telephone2 xsi:nil="true"></Telephone2>
-          <Telephone3 xsi:nil="true"></Telephone3>
-          <TimeZoneRuleVersionNumber xsi:nil="true"></TimeZoneRuleVersionNumber>
-          <UPSZone xsi:nil="true"></UPSZone>
-          <UTCOffset xsi:nil="true"></UTCOffset>
-          <UTCConversionTimeZoneCode xsi:nil="true"></UTCConversionTimeZoneCode>
+          <StateOrProvince xsi:nil="true" />
+          <Telephone1 xsi:nil="true" />
+          <Telephone2 xsi:nil="true" />
+          <Telephone3 xsi:nil="true" />
+          <TimeZoneRuleVersionNumber xsi:nil="true" />
+          <UPSZone xsi:nil="true" />
+          <UTCOffset xsi:nil="true" />
+          <UTCConversionTimeZoneCode xsi:nil="true" />
         </Address>
       </Addresses>
     </Publisher>

--- a/src/Dataverse/templates/pp-solution/SolutionLogicalNameExample.csproj
+++ b/src/Dataverse/templates/pp-solution/SolutionLogicalNameExample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.15">
+<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.16">
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <SolutionRootPath>SolutionDeclarationsRoot</SolutionRootPath>

--- a/src/Dataverse/templates/pp-test-script/.template.config/template.json
+++ b/src/Dataverse/templates/pp-test-script/.template.config/template.json
@@ -41,7 +41,8 @@
         {
           "text": "Installing npm packages"
         }
-      ]
+      ],
+      "description": "Install packages"
     },
     {
 			"actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",

--- a/src/Dataverse/templates/pp-test-ui/.template.config/template.json
+++ b/src/Dataverse/templates/pp-test-ui/.template.config/template.json
@@ -191,7 +191,8 @@
         {
           "text": "If the script does not start automatically, run the command: dotnet user-secrets init"
         }
-      ]
+      ],
+      "description": "Enable user secrets"
     },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -204,7 +205,8 @@
         {
           "text": "Generating mock step bindings"
         }
-      ]
+      ],
+      "description": "Enable Cucumber support"
     },
     {
       "description": "Add generated project to .sln file",

--- a/src/Dataverse/templates/pp-webresource/.template.config/template.json
+++ b/src/Dataverse/templates/pp-webresource/.template.config/template.json
@@ -41,7 +41,8 @@
                 "executable": "pwsh",
                 "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/SetWebresourceType.ps1\"",
                 "redirectStandardOutput": "false"
-            }
+            },
+            "description": "Set webresource type"
         },
         {
             "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -49,7 +50,8 @@
                 "executable": "pwsh",
                 "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/AddToSolution.ps1\"",
                 "redirectStandardOutput": "false"
-            }
+            },
+            "description": "Add to solution"
         },
         {
             "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -57,7 +59,8 @@
                 "executable": "pwsh",
                 "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/AddToCustomizationsXml.ps1\"",
                 "redirectStandardOutput": "false"
-            }
+            },
+            "description": "Add to customizations XML"
         },
         {
             "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -65,7 +68,8 @@
                 "executable": "pwsh",
                 "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/SetupWRDataFile.ps1\"",
                 "redirectStandardOutput": "false"
-            }
+            },
+            "description": "Setup WR data file"
         },
         {
             "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
@@ -73,7 +77,8 @@
                 "executable": "pwsh",
                 "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/Cleanup.ps1\"",
                 "redirectStandardOutput": "false"
-            }
+            },
+            "description": "Cleanup"
         }
     ]
 }

--- a/src/Dataverse/templates/pp-workflow-activity/.template.scripts/InitializePlugin.ps1
+++ b/src/Dataverse/templates/pp-workflow-activity/.template.scripts/InitializePlugin.ps1
@@ -38,6 +38,7 @@ if (Test-Path $workflowBaseSource) {
 # --- 4. Locate the generated .csproj ---
 $csprojFile = Get-ChildItem -Path . -Filter *.csproj | Select-Object -First 1
 if (-not $csprojFile) {
+    Write-Error "Could not find a .csproj file in the current directory."
     exit 1
 }
 $projectName = [System.IO.Path]::GetFileNameWithoutExtension($csprojFile.Name)

--- a/src/Dataverse/templates/pp-workflow-activity/SolutionLogicalNameExample.csproj
+++ b/src/Dataverse/templates/pp-workflow-activity/SolutionLogicalNameExample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.15">
+<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.16">
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
## Summary

Improves template quality for AI agent scaffolding success and error diagnostics.

### Error Messages
- Added `Write-Error` before all bare `exit 1` calls in post-action scripts (14 .ps1 files)
- Scripts now report *what* failed instead of silently exiting

### Post-Action Descriptions
- Added `description` field to all 121 post-actions across 20 template.json files
- Error reports now show human-readable labels instead of raw GUIDs

### Parameter Metadata
- Marked functionally-required parameters as `isRequired` in pp-app-model, pp-entity-form, pp-sitemap-*, pp-app-model-component
- Fixed pp-entity-form `EntitySchemaName` default from `"."` to `"exampleentity"`
- Clarified prefix conventions across 22 templates:
  - `LogicalName` = without prefix (added automatically)
  - `EntitySchemaName`/`EntityLogicalName`/`AppName`/`ReferencedEntityName` = with prefix

### Template Fixes
- Fixed `FlattenSolutionRootIfInplace.ps1` — was failing when `SolutionRootPath="."` because it tried to move files into themselves, blocking the name sanitization script

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>