### PR TITLE
fix: cross-platform .csx path separators + auto-generate RoleId

### DIFF
--- a/src/Dataverse/templates/pp-app-security-role/.template.scripts/GenerateRolePrivileges.csx
+++ b/src/Dataverse/templates/pp-app-security-role/.template.scripts/GenerateRolePrivileges.csx
@@ -19,7 +19,7 @@ for (int i = 0; i < guids.Count; i++)
     guids[i] = guids[i].Trim();
 }
 
-var filePath = ".\\.template.scripts\\appaccess.xml";
+var filePath = Path.Combine(".", ".template.scripts", "appaccess.xml");
 
 Directory.CreateDirectory(Path.GetDirectoryName(filePath));
 

--- a/src/Dataverse/templates/pp-plugin-assembly/.template.scripts/GenerateAssembly.csx
+++ b/src/Dataverse/templates/pp-plugin-assembly/.template.scripts/GenerateAssembly.csx
@@ -12,7 +12,7 @@ string pluginAssemblyId = "pluginguididexample";
 string csprojPath = Directory.GetFiles(pluginRootPath, "*.csproj").FirstOrDefault();
 if (csprojPath == null) throw new Exception("csproj not found");
 string projectDirectory = Path.GetDirectoryName(csprojPath);
-string sdkPath = @$"{projectDirectory}\bin\Debug\net462\Microsoft.Xrm.Sdk.dll"; 
+string sdkPath = Path.Combine(projectDirectory, "bin", "Debug", "net462", "Microsoft.Xrm.Sdk.dll"); 
 Assembly.LoadFrom(sdkPath);
 string csprojFileName = Path.GetFileNameWithoutExtension(csprojPath);
 
@@ -95,7 +95,7 @@ solutionDoc.AppendChild(solutionRoot);
 
 Directory.CreateDirectory(Path.Combine(Directory.GetCurrentDirectory(), ".template.temp"));
 
-solutionDoc.Save(".template.temp\\RootComponent.xml");
+solutionDoc.Save(Path.Combine(".template.temp", "RootComponent.xml"));
 
 
 

--- a/src/Dataverse/templates/pp-security-role-privilege/.template.scripts/GenerateRolePrivileges.csx
+++ b/src/Dataverse/templates/pp-security-role-privilege/.template.scripts/GenerateRolePrivileges.csx
@@ -21,7 +21,7 @@ var permissions = JsonSerializer.Deserialize<List<Privilege>>(fixedJson, new Jso
     PropertyNameCaseInsensitive = true
 });
 
-var filePath = ".\\.template.scripts\\privileges.xml";
+var filePath = Path.Combine(".", ".template.scripts", "privileges.xml");
 
 using (var writer = new StreamWriter(filePath))
 {


### PR DESCRIPTION
Fixes all .csx script failures on macOS/Linux and the RoleId GUID issue.

### Cross-platform paths (fixes issues #1, #2, #4 from test report)
- `GenerateAssembly.csx`: SDK DLL path + RootComponent.xml output — backslash → `Path.Combine`
- `GenerateRolePrivileges.csx` (security-role-privilege): privileges.xml path
- `GenerateRolePrivileges.csx` (app-security-role): appaccess.xml path

### RoleId auto-generation (fixes issue #5)
- Changed `pp-security-role` RoleId from `type: parameter` with `defaultValue: "."` to `type: generated` with GUID generator

### Tested on macOS:
- ✅ Plugin assembly: PluginAssemblies/ created, dll.data.xml generated, RootComponent type=91 in Solution.xml
- ✅ Security role: GUID auto-generated
- ✅ Security role privileges: RolePrivileges correctly generated

Requires `dotnet-script` global tool (`dotnet tool install --global dotnet-script`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>