### PR TITLE
fix: AddFilteringAttributes.csx crash — fixes buildnameexample + empty FilteringAttributes

### DIFF
--- a/src/Dataverse/TALXIS.DevKit.Templates.Dataverse.csproj
+++ b/src/Dataverse/TALXIS.DevKit.Templates.Dataverse.csproj
@@ -4,7 +4,7 @@
 		<!-- The package metadata. Fill in the properties marked as TODO below -->
 		<!-- Follow the instructions on https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices -->
 		<PackageId>TALXIS.DevKit.Templates.Dataverse</PackageId>
-		<PackageVersion>1.15</PackageVersion>
+		<PackageVersion>1.16</PackageVersion>
 		<Title>TALXIS.DevKit.Templates.Dataverse</Title>
 		<Authors>NETWORG</Authors>
 		<Description>A collection of .NET templates for creating Power Platform components using a code-first approach. These templates will allow you to quickly scaffold projects with pre-configured settings and structure.</Description>

--- a/src/Dataverse/templates/pp-plugin-assembly-step/.template.scripts/AddFilteringAttributes.csx
+++ b/src/Dataverse/templates/pp-plugin-assembly-step/.template.scripts/AddFilteringAttributes.csx
@@ -1,5 +1,3 @@
-#r "Newtonsoft.Json"
-using Newtonsoft.Json;
 using System.Xml;
 using System;
 using System.Collections.Generic;
@@ -19,16 +17,10 @@ string cleanedString = json
 
 string[] entities = cleanedString.Split(',', StringSplitOptions.RemoveEmptyEntries);
 
-var jsonObject = new { entities = entities };
-
-string entitiesList = JsonConvert.SerializeObject(jsonObject, Newtonsoft.Json.Formatting.Indented);
-
-dynamic entityData = JsonConvert.DeserializeObject(entitiesList);
-
 var attributes = new List<string>();
-foreach (string entity in entityData.entities)
+foreach (string entity in entities)
 {
-    attributes.Add($"{entity.Trim()}");
+    attributes.Add(entity.Trim());
 }
 
 XmlDocument doc = new XmlDocument();


### PR DESCRIPTION
## Bug

`AddFilteringAttributes.csx` crashes at runtime on line 29 with:

```
Microsoft.CSharp.RuntimeBinder.RuntimeBinderException:
'Newtonsoft.Json.Linq.JObject' does not contain a definition for 'entities'
```

`JsonConvert.DeserializeObject()` returns a `JObject`, and dynamic property access (`entityData.entities`) fails in dotnet-script. This means **both** the FilteringAttributes population and the `buildnameexample` → actual assembly name replacement never execute.

## Fix

The Newtonsoft JSON round-trip was unnecessary — the `entities` string array (line 18) already contains the parsed attribute names. This PR:

- Removes the serialize → deserialize → dynamic access pattern
- Iterates directly over the `entities` array
- Removes the now-unused `#r "Newtonsoft.Json"` and `using Newtonsoft.Json` directives