### PR TITLE
fix: bump Microsoft.Extensions.Caching.Memory 8.0.0→8.0.1 (CVE-2024-43483)

### DIFF
--- a/src/Dataverse/templates/pp-test-ui/TestProjectName.csproj
+++ b/src/Dataverse/templates/pp-test-ui/TestProjectName.csproj
@@ -22,7 +22,7 @@
 	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Resolves dependabot alert #35 — .NET Denial of Service vulnerability in Microsoft.Extensions.Caching.Memory 8.0.0.