### PR TITLE
chore: unified release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
 name: publish
+
 on:
-  workflow_dispatch: # Allow running the workflow manually from the GitHub UI
-  push:
-    branches:
-      - 'master'       # Run the workflow when pushing to the main branch
+  release:
+    types: [published]
+  workflow_dispatch:
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -17,49 +17,97 @@ defaults:
     shell: pwsh
 
 jobs:
+  resolve-version:
+    runs-on: ubuntu-latest
+    outputs:
+      package-version: ${{ steps.version.outputs.package-version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Resolve version
+        id: version
+        run: |
+          if ("${{ github.event_name }}" -eq "release") {
+            $tag = "${{ github.event.release.tag_name }}" -replace '^v', ''
+            if ($tag -notmatch '^\d+\.\d+(\.\d+)?(-[a-zA-Z0-9\.\-]+)?$') {
+              Write-Error "Invalid tag format '${{ github.event.release.tag_name }}'. Expected vX.Y or vX.Y.Z."
+              exit 1
+            }
+            "package-version=$tag" >> $env:GITHUB_OUTPUT
+          } else {
+            [xml]$csproj = Get-Content "src/Dataverse/TALXIS.DevKit.Templates.Dataverse.csproj"
+            $ver = $csproj.Project.PropertyGroup.PackageVersion
+            "package-version=$ver" >> $env:GITHUB_OUTPUT
+          }
+      - name: Print resolved version
+        run: Write-Host "Package version = ${{ steps.version.outputs.package-version }}"
+
   create_nuget:
+    needs: [resolve-version]
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0 # Get all history to allow automatic versioning using MinVer
-
-    # Install the .NET SDK indicated in the global.json file
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-
-    # Create the NuGet package in the folder from the environment variable NuGetDirectory
-    - run: dotnet pack TALXIS.DevKit.Templates.sln --configuration Release
-
-    # Publish the NuGet package as an artifact, so they can be used in the following jobs
-    - uses: actions/upload-artifact@v4
-      with:
-        name: nuget
-        if-no-files-found: error
-        retention-days: 7
-        path: src/Dataverse/bin/Release/*.nupkg
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+      - name: Assemble cumulative release notes
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $releases = gh release list --limit 100 --json tagName --template '{{range .}}{{.tagName}}{{"\n"}}{{end}}'
+          $changelog = ""
+          foreach ($tag in ($releases -split "`n" | Where-Object { $_ -ne "" })) {
+            $version = $tag -replace '^v', ''
+            $body = gh release view $tag --json body --template '{{.body}}'
+            $plain = $body `
+              -replace '#{1,6}\s*', '' `
+              -replace '\*{1,2}([^*]+)\*{1,2}', '$1' `
+              -replace '`([^`]+)`', '$1' `
+              -replace '\[([^\]]+)\]\([^\)]+\)', '$1' `
+              -replace '```[\s\S]*?```', '' `
+              -replace '\r\n', "`n" `
+              -replace '\r', "`n"
+            $indented = ($plain -split "`n" | ForEach-Object {
+              if ($_.Trim() -ne "") { "  $_" } else { "" }
+            }) -join "`n"
+            $changelog += "${version}:`n${indented}`n`n"
+          }
+          Set-Content -Path "release-notes.txt" -Value $changelog -Encoding UTF8
+      - name: Write release notes targets file
+        if: github.event_name == 'release'
+        run: |
+          $notes = Get-Content "release-notes.txt" -Raw -Encoding UTF8
+          $escaped = [System.Security.SecurityElement]::Escape($notes)
+          $targetsContent = @"
+          <Project>
+            <PropertyGroup>
+              <PackageReleaseNotes>$escaped</PackageReleaseNotes>
+            </PropertyGroup>
+          </Project>
+          "@
+          Set-Content -Path "src/Directory.Build.targets" -Value $targetsContent -Encoding UTF8
+      - name: Create NuGet package
+        run: |
+          $pkgVer = "${{ needs.resolve-version.outputs.package-version }}"
+          dotnet pack TALXIS.DevKit.Templates.sln --configuration Release -p:PackageVersion=$pkgVer
+      - uses: actions/upload-artifact@v4
+        with:
+          name: nuget
+          if-no-files-found: error
+          retention-days: 7
+          path: src/Dataverse/bin/Release/*.nupkg
 
   deploy:
-    # Publish only when creating a GitHub Release
-    # https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository
-    # You can update this logic if you want to manage releases differently
-    # if: github.event_name == 'release'
+    needs: [create_nuget]
     runs-on: ubuntu-latest
-    needs: [ create_nuget ]
     steps:
-      # Download the NuGet package created in the previous job
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v4
         with:
           name: nuget
           path: ${{ env.NuGetDirectory }}
-
-      # Install the .NET SDK indicated in the global.json file
-      - name: Setup .NET Core
+      - name: Setup .NET
         uses: actions/setup-dotnet@v4
-
-      # Publish all NuGet packages to NuGet.org
-      # Use --skip-duplicate to prevent errors if a package with the same version already exists.
-      # If you retry a failed workflow, already published packages will be skipped without error.
       - name: Publish NuGet package
         run: |
           foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Include *.nupkg)) {

--- a/README.md
+++ b/README.md
@@ -652,13 +652,34 @@ We are happy to collaborate with developers and contributors interested in enhan
 
 ### Local building and debugging
 
-#### Using your local version of templates
+**Build the template package locally:**
+```sh
+dotnet pack --configuration Debug
+```
 
-Use the provided VS Code task to build the project and update the local templates:
+The `.nupkg` is output to `src/Dataverse/bin/Debug/`. To use it with the CLI, add it as a local NuGet source (see [cross-repo instructions](https://github.com/TALXIS/tools-cli#working-with-all-three-repos-locally)).
 
-1. Open the Command Palette (Ctrl+Shift+P or Cmd+Shift+P)
-2. Search for "Tasks: Run Task" and select it
-3. Choose "Update local templates" from the list
+For `dotnet new` (standalone template usage outside the CLI):
+```sh
+dotnet new install src/Dataverse/bin/Debug/TALXIS.DevKit.Templates.Dataverse.*.nupkg --force
+```
+
+Or use the VS Code task: Command Palette → "Tasks: Run Task" → "Update local templates".
+
+### Working with all three repos locally
+
+See the [tools-cli README](https://github.com/TALXIS/tools-cli#working-with-all-three-repos-locally) for instructions on testing local versions of the CLI, templates, and build SDK together.
+
+### Versioning & Release
+
+Releases are published through [GitHub Releases](https://github.com/TALXIS/tools-devkit-templates/releases):
+
+1. Go to **Releases** → **Draft a new release**
+2. Create a tag in the format `vX.Y.Z` (e.g. `v1.17.0`)
+3. Write the changelog in the release body
+4. Click **Publish release**
+
+The publish workflow builds the NuGet package with the tag version and pushes it to [nuget.org](https://www.nuget.org/packages/TALXIS.DevKit.Templates.Dataverse). Release notes are embedded in the package.
 
 ## Contact us
 

--- a/src/Dataverse/templates/pp-app-code/CodeAppExample.csproj
+++ b/src/Dataverse/templates/pp-app-code/CodeAppExample.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.16">
+<Project Sdk="TALXIS.DevKit.Build.Sdk/1.0.0">
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <AppName>codeappexample</AppName>

--- a/src/Dataverse/templates/pp-package/pdpackageexamplename.csproj
+++ b/src/Dataverse/templates/pp-package/pdpackageexamplename.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.16">
+<Project Sdk="TALXIS.DevKit.Build.Sdk/1.0.0">
   <PropertyGroup>
     <ProjectType>PDPackage</ProjectType>
     <TargetFramework>net472</TargetFramework>

--- a/src/Dataverse/templates/pp-pcf/examplesourcename.csproj
+++ b/src/Dataverse/templates/pp-pcf/examplesourcename.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.16">
+<Project Sdk="TALXIS.DevKit.Build.Sdk/1.0.0">
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <Name>examplesourcename</Name>

--- a/src/Dataverse/templates/pp-plugin/SolutionLogicalNameExample.csproj
+++ b/src/Dataverse/templates/pp-plugin/SolutionLogicalNameExample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.16">
+<Project Sdk="TALXIS.DevKit.Build.Sdk/1.0.0">
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <SignAssembly>true</SignAssembly>

--- a/src/Dataverse/templates/pp-script-library/examplesourcename.csproj
+++ b/src/Dataverse/templates/pp-script-library/examplesourcename.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.16">
+<Project Sdk="TALXIS.DevKit.Build.Sdk/1.0.0">
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <ProjectType>ScriptLibrary</ProjectType>

--- a/src/Dataverse/templates/pp-solution/SolutionLogicalNameExample.csproj
+++ b/src/Dataverse/templates/pp-solution/SolutionLogicalNameExample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.16">
+<Project Sdk="TALXIS.DevKit.Build.Sdk/1.0.0">
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <SolutionRootPath>SolutionDeclarationsRoot</SolutionRootPath>

--- a/src/Dataverse/templates/pp-workflow-activity/SolutionLogicalNameExample.csproj
+++ b/src/Dataverse/templates/pp-workflow-activity/SolutionLogicalNameExample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="TALXIS.DevKit.Build.Sdk/0.0.0.16">
+<Project Sdk="TALXIS.DevKit.Build.Sdk/1.0.0">
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
Aligns release process with tools-cli and tools-devkit-build:
- **Trigger**: GitHub Release published (was push to master)
- **Version**: SemVer from tag name (was manual in .csproj)
- **Release notes**: cumulative from all GitHub releases, embedded in NuGet package
- **README**: versioning docs, local dev, cross-repo instructions