### PR TITLE
fix: Align Solution.xml template with SolutionPackager export format

### DIFF
--- a/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
@@ -237,6 +237,19 @@
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
       "args": {
         "executable": "pwsh",
+        "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/SortEntityAttributes.ps1\"",
+        "redirectStandardOutput": "false"
+      },
+      "manualInstructions": [
+        { "text": "Sorting entity attributes alphabetically by PhysicalName" }
+      ],
+      "continueOnError": false,
+      "description": "Sorting entity attributes"
+    },
+    {
+      "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
+      "args": {
+        "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/Cleanup.ps1\"",
         "redirectStandardOutput": "false"
       },

--- a/src/Dataverse/templates/pp-entity-attribute/.template.scripts/SortEntityAttributes.ps1
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.scripts/SortEntityAttributes.ps1
@@ -1,0 +1,32 @@
+$entityDir = Get-ChildItem -Path "SolutionDeclarationsRoot/Entities" -Directory | Select-Object -First 1
+if (-not $entityDir) { exit 0 }
+
+$entityXmlPath = Join-Path $entityDir.FullName "Entity.xml"
+if (-not (Test-Path $entityXmlPath)) { exit 0 }
+
+[xml]$xml = Get-Content -Path $entityXmlPath -Raw
+
+$attributesNodes = $xml.SelectNodes('//entity/attributes')
+foreach ($attributesNode in $attributesNodes) {
+    $attrs = @($attributesNode.SelectNodes('attribute'))
+    if ($attrs.Count -eq 0) { continue }
+
+    $sorted = $attrs | Sort-Object { $_.GetAttribute('PhysicalName').ToLowerInvariant() }
+
+    foreach ($a in $attrs) {
+        $attributesNode.RemoveChild($a) | Out-Null
+    }
+    foreach ($a in $sorted) {
+        $attributesNode.AppendChild($a) | Out-Null
+    }
+}
+
+$settings = New-Object System.Xml.XmlWriterSettings
+$settings.Indent = $true
+$settings.NewLineHandling = [System.Xml.NewLineHandling]::None
+$settings.OmitXmlDeclaration = $false
+$settings.Encoding = New-Object System.Text.UTF8Encoding($true)
+
+$writer = [System.Xml.XmlWriter]::Create($entityXmlPath, $settings)
+$xml.Save($writer)
+$writer.Close()

--- a/src/Dataverse/templates/pp-entity-attribute/.template.scripts/SortEntityAttributes.ps1
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.scripts/SortEntityAttributes.ps1
@@ -1,32 +1,31 @@
-$entityDir = Get-ChildItem -Path "SolutionDeclarationsRoot/Entities" -Directory | Select-Object -First 1
-if (-not $entityDir) { exit 0 }
+$entityXmlPaths = Get-ChildItem -Path "SolutionDeclarationsRoot/Entities" -Recurse -File -Filter "Entity.xml" -ErrorAction SilentlyContinue
+if (-not $entityXmlPaths) { exit 0 }
 
-$entityXmlPath = Join-Path $entityDir.FullName "Entity.xml"
-if (-not (Test-Path $entityXmlPath)) { exit 0 }
+foreach ($entityXmlFile in $entityXmlPaths) {
+    [xml]$xml = Get-Content -Path $entityXmlFile.FullName -Raw
 
-[xml]$xml = Get-Content -Path $entityXmlPath -Raw
+    $attributesNodes = $xml.SelectNodes('//entity/attributes')
+    foreach ($attributesNode in $attributesNodes) {
+        $attrs = @($attributesNode.SelectNodes('attribute'))
+        if ($attrs.Count -eq 0) { continue }
 
-$attributesNodes = $xml.SelectNodes('//entity/attributes')
-foreach ($attributesNode in $attributesNodes) {
-    $attrs = @($attributesNode.SelectNodes('attribute'))
-    if ($attrs.Count -eq 0) { continue }
+        $sorted = $attrs | Sort-Object { $_.GetAttribute('PhysicalName').ToLowerInvariant() }
 
-    $sorted = $attrs | Sort-Object { $_.GetAttribute('PhysicalName').ToLowerInvariant() }
-
-    foreach ($a in $attrs) {
-        $attributesNode.RemoveChild($a) | Out-Null
+        foreach ($a in $attrs) {
+            $attributesNode.RemoveChild($a) | Out-Null
+        }
+        foreach ($a in $sorted) {
+            $attributesNode.AppendChild($a) | Out-Null
+        }
     }
-    foreach ($a in $sorted) {
-        $attributesNode.AppendChild($a) | Out-Null
-    }
+
+    $settings = New-Object System.Xml.XmlWriterSettings
+    $settings.Indent = $true
+    $settings.NewLineHandling = [System.Xml.NewLineHandling]::None
+    $settings.OmitXmlDeclaration = $false
+    $settings.Encoding = New-Object System.Text.UTF8Encoding($true)
+
+    $writer = [System.Xml.XmlWriter]::Create($entityXmlFile.FullName, $settings)
+    $xml.Save($writer)
+    $writer.Close()
 }
-
-$settings = New-Object System.Xml.XmlWriterSettings
-$settings.Indent = $true
-$settings.NewLineHandling = [System.Xml.NewLineHandling]::None
-$settings.OmitXmlDeclaration = $false
-$settings.Encoding = New-Object System.Text.UTF8Encoding($true)
-
-$writer = [System.Xml.XmlWriter]::Create($entityXmlPath, $settings)
-$xml.Save($writer)
-$writer.Close()

--- a/src/Dataverse/templates/pp-entity/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity/.template.config/template.json
@@ -835,6 +835,17 @@
 			"actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
 			"args": {
 				"executable": "pwsh",
+				"args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/SortEntityAttributes.ps1\"",
+				"redirectStandardOutput": "false"
+			},
+			"manualInstructions": [{ "text": "Sorting entity attributes alphabetically by PhysicalName" }],
+			"continueOnError": false,
+			"description": "Sorting entity attributes"
+		},
+		{
+			"actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
+			"args": {
+				"executable": "pwsh",
 				"args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/Cleanup.ps1\"",
 				"redirectStandardOutput": "false"
 			},

--- a/src/Dataverse/templates/pp-entity/.template.scripts/SortEntityAttributes.ps1
+++ b/src/Dataverse/templates/pp-entity/.template.scripts/SortEntityAttributes.ps1
@@ -1,0 +1,32 @@
+$entityDir = Get-ChildItem -Path "SolutionDeclarationsRoot/Entities" -Directory | Select-Object -First 1
+if (-not $entityDir) { exit 0 }
+
+$entityXmlPath = Join-Path $entityDir.FullName "Entity.xml"
+if (-not (Test-Path $entityXmlPath)) { exit 0 }
+
+[xml]$xml = Get-Content -Path $entityXmlPath -Raw
+
+$attributesNodes = $xml.SelectNodes('//entity/attributes')
+foreach ($attributesNode in $attributesNodes) {
+    $attrs = @($attributesNode.SelectNodes('attribute'))
+    if ($attrs.Count -eq 0) { continue }
+
+    $sorted = $attrs | Sort-Object { $_.GetAttribute('PhysicalName').ToLowerInvariant() }
+
+    foreach ($a in $attrs) {
+        $attributesNode.RemoveChild($a) | Out-Null
+    }
+    foreach ($a in $sorted) {
+        $attributesNode.AppendChild($a) | Out-Null
+    }
+}
+
+$settings = New-Object System.Xml.XmlWriterSettings
+$settings.Indent = $true
+$settings.NewLineHandling = [System.Xml.NewLineHandling]::None
+$settings.OmitXmlDeclaration = $false
+$settings.Encoding = New-Object System.Text.UTF8Encoding($true)
+
+$writer = [System.Xml.XmlWriter]::Create($entityXmlPath, $settings)
+$xml.Save($writer)
+$writer.Close()

--- a/src/Dataverse/templates/pp-entity/.template.scripts/SortEntityAttributes.ps1
+++ b/src/Dataverse/templates/pp-entity/.template.scripts/SortEntityAttributes.ps1
@@ -1,32 +1,31 @@
-$entityDir = Get-ChildItem -Path "SolutionDeclarationsRoot/Entities" -Directory | Select-Object -First 1
-if (-not $entityDir) { exit 0 }
+$entityXmlPaths = Get-ChildItem -Path "SolutionDeclarationsRoot/Entities" -Recurse -File -Filter "Entity.xml" -ErrorAction SilentlyContinue
+if (-not $entityXmlPaths) { exit 0 }
 
-$entityXmlPath = Join-Path $entityDir.FullName "Entity.xml"
-if (-not (Test-Path $entityXmlPath)) { exit 0 }
+foreach ($entityXmlFile in $entityXmlPaths) {
+    [xml]$xml = Get-Content -Path $entityXmlFile.FullName -Raw
 
-[xml]$xml = Get-Content -Path $entityXmlPath -Raw
+    $attributesNodes = $xml.SelectNodes('//entity/attributes')
+    foreach ($attributesNode in $attributesNodes) {
+        $attrs = @($attributesNode.SelectNodes('attribute'))
+        if ($attrs.Count -eq 0) { continue }
 
-$attributesNodes = $xml.SelectNodes('//entity/attributes')
-foreach ($attributesNode in $attributesNodes) {
-    $attrs = @($attributesNode.SelectNodes('attribute'))
-    if ($attrs.Count -eq 0) { continue }
+        $sorted = $attrs | Sort-Object { $_.GetAttribute('PhysicalName').ToLowerInvariant() }
 
-    $sorted = $attrs | Sort-Object { $_.GetAttribute('PhysicalName').ToLowerInvariant() }
-
-    foreach ($a in $attrs) {
-        $attributesNode.RemoveChild($a) | Out-Null
+        foreach ($a in $attrs) {
+            $attributesNode.RemoveChild($a) | Out-Null
+        }
+        foreach ($a in $sorted) {
+            $attributesNode.AppendChild($a) | Out-Null
+        }
     }
-    foreach ($a in $sorted) {
-        $attributesNode.AppendChild($a) | Out-Null
-    }
+
+    $settings = New-Object System.Xml.XmlWriterSettings
+    $settings.Indent = $true
+    $settings.NewLineHandling = [System.Xml.NewLineHandling]::None
+    $settings.OmitXmlDeclaration = $false
+    $settings.Encoding = New-Object System.Text.UTF8Encoding($true)
+
+    $writer = [System.Xml.XmlWriter]::Create($entityXmlFile.FullName, $settings)
+    $xml.Save($writer)
+    $writer.Close()
 }
-
-$settings = New-Object System.Xml.XmlWriterSettings
-$settings.Indent = $true
-$settings.NewLineHandling = [System.Xml.NewLineHandling]::None
-$settings.OmitXmlDeclaration = $false
-$settings.Encoding = New-Object System.Text.UTF8Encoding($true)
-
-$writer = [System.Xml.XmlWriter]::Create($entityXmlPath, $settings)
-$xml.Save($writer)
-$writer.Close()

--- a/src/Dataverse/templates/pp-entity/SolutionDeclarationsRoot/Entities/examplepublisherprefix_examplecustomentity/Entity.xml
+++ b/src/Dataverse/templates/pp-entity/SolutionDeclarationsRoot/Entities/examplepublisherprefix_examplecustomentity/Entity.xml
@@ -291,17 +291,17 @@
             <Description description="Unique identifier of the delegate user who modified the record." languagecode="1033" />
           </Descriptions>
         </attribute>
-        <attribute PhysicalName="examplepublisherprefix_name">
-          <Type>nvarchar</Type>
-          <Name>examplepublisherprefix_name</Name>
-          <LogicalName>examplepublisherprefix_name</LogicalName>
-          <RequiredLevel>required</RequiredLevel>
-          <DisplayMask>PrimaryName|ValidForAdvancedFind|ValidForForm|ValidForGrid|RequiredForForm</DisplayMask>
-          <ImeMode>auto</ImeMode>
-          <ValidForUpdateApi>1</ValidForUpdateApi>
+        <attribute PhysicalName="OverriddenCreatedOn">
+          <Type>datetime</Type>
+          <Name>overriddencreatedon</Name>
+          <LogicalName>overriddencreatedon</LogicalName>
+          <RequiredLevel>none</RequiredLevel>
+          <DisplayMask>ValidForAdvancedFind|ValidForGrid</DisplayMask>
+          <ImeMode>inactive</ImeMode>
+          <ValidForUpdateApi>0</ValidForUpdateApi>
           <ValidForReadApi>1</ValidForReadApi>
           <ValidForCreateApi>1</ValidForCreateApi>
-          <IsCustomField>1</IsCustomField>
+          <IsCustomField>0</IsCustomField>
           <IsAuditEnabled>1</IsAuditEnabled>
           <IsSecured>0</IsSecured>
           <IntroducedVersion>1.0</IntroducedVersion>
@@ -317,18 +317,18 @@
           <CanModifyIsSortableSettings>1</CanModifyIsSortableSettings>
           <IsDataSourceSecret>0</IsDataSourceSecret>
           <AutoNumberFormat></AutoNumberFormat>
-          <IsSearchable>1</IsSearchable>
+          <IsSearchable>0</IsSearchable>
           <IsFilterable>0</IsFilterable>
-          <IsRetrievable>1</IsRetrievable>
+          <IsRetrievable>0</IsRetrievable>
           <IsLocalizable>0</IsLocalizable>
-          <Format>text</Format>
-          <MaxLength>100</MaxLength>
-          <Length>200</Length>
+          <Format>date</Format>
+          <CanChangeDateTimeBehavior>0</CanChangeDateTimeBehavior>
+          <Behavior>1</Behavior>
           <displaynames>
-            <displayname description="Name" languagecode="1033" />
+            <displayname description="Record Created On" languagecode="1033" />
           </displaynames>
           <Descriptions>
-            <Description description="" languagecode="1033" />
+            <Description description="Date and time that the record was migrated." languagecode="1033" />
           </Descriptions>
         </attribute>
         <attribute PhysicalName="examplepublisherprefix_examplecustomentityid">
@@ -368,17 +368,17 @@
             <Description description="Unique identifier for entity instances" languagecode="1033" />
           </Descriptions>
         </attribute>
-        <attribute PhysicalName="OverriddenCreatedOn">
-          <Type>datetime</Type>
-          <Name>overriddencreatedon</Name>
-          <LogicalName>overriddencreatedon</LogicalName>
-          <RequiredLevel>none</RequiredLevel>
-          <DisplayMask>ValidForAdvancedFind|ValidForGrid</DisplayMask>
-          <ImeMode>inactive</ImeMode>
-          <ValidForUpdateApi>0</ValidForUpdateApi>
+        <attribute PhysicalName="examplepublisherprefix_name">
+          <Type>nvarchar</Type>
+          <Name>examplepublisherprefix_name</Name>
+          <LogicalName>examplepublisherprefix_name</LogicalName>
+          <RequiredLevel>required</RequiredLevel>
+          <DisplayMask>PrimaryName|ValidForAdvancedFind|ValidForForm|ValidForGrid|RequiredForForm</DisplayMask>
+          <ImeMode>auto</ImeMode>
+          <ValidForUpdateApi>1</ValidForUpdateApi>
           <ValidForReadApi>1</ValidForReadApi>
           <ValidForCreateApi>1</ValidForCreateApi>
-          <IsCustomField>0</IsCustomField>
+          <IsCustomField>1</IsCustomField>
           <IsAuditEnabled>1</IsAuditEnabled>
           <IsSecured>0</IsSecured>
           <IntroducedVersion>1.0</IntroducedVersion>
@@ -394,18 +394,18 @@
           <CanModifyIsSortableSettings>1</CanModifyIsSortableSettings>
           <IsDataSourceSecret>0</IsDataSourceSecret>
           <AutoNumberFormat></AutoNumberFormat>
-          <IsSearchable>0</IsSearchable>
+          <IsSearchable>1</IsSearchable>
           <IsFilterable>0</IsFilterable>
-          <IsRetrievable>0</IsRetrievable>
+          <IsRetrievable>1</IsRetrievable>
           <IsLocalizable>0</IsLocalizable>
-          <Format>date</Format>
-          <CanChangeDateTimeBehavior>0</CanChangeDateTimeBehavior>
-          <Behavior>1</Behavior>
+          <Format>text</Format>
+          <MaxLength>100</MaxLength>
+          <Length>200</Length>
           <displaynames>
-            <displayname description="Record Created On" languagecode="1033" />
+            <displayname description="Name" languagecode="1033" />
           </displaynames>
           <Descriptions>
-            <Description description="Date and time that the record was migrated." languagecode="1033" />
+            <Description description="" languagecode="1033" />
           </Descriptions>
         </attribute>
         <!--#if (EntityType == "Elastic") -->

--- a/src/Dataverse/templates/pp-entity/SolutionDeclarationsRoot/Entities/examplepublisherprefix_examplecustomentity/Entity.xml
+++ b/src/Dataverse/templates/pp-entity/SolutionDeclarationsRoot/Entities/examplepublisherprefix_examplecustomentity/Entity.xml
@@ -3690,6 +3690,7 @@
       <ChangeTrackingEnabled>0</ChangeTrackingEnabled>
       <CanChangeTrackingBeEnabled>1</CanChangeTrackingBeEnabled>
       <IsEnabledForExternalChannels>0</IsEnabledForExternalChannels>
+      <IsMSTeamsIntegrationEnabled>0</IsMSTeamsIntegrationEnabled>
       <IsSolutionAware>0</IsSolutionAware>
       <!--#if (EntityType == "Activity") -->
       <HasRelatedNotes>True</HasRelatedNotes>

--- a/src/Dataverse/templates/pp-entity/SolutionDeclarationsRoot/Entities/examplepublisherprefix_examplecustomentity/Entity.xml
+++ b/src/Dataverse/templates/pp-entity/SolutionDeclarationsRoot/Entities/examplepublisherprefix_examplecustomentity/Entity.xml
@@ -331,7 +331,7 @@
             <Description description="Date and time that the record was migrated." languagecode="1033" />
           </Descriptions>
         </attribute>
-        <attribute PhysicalName="examplepublisherprefix_examplecustomentityid">
+        <attribute PhysicalName="examplepublisherprefix_examplecustomentityId">
           <Type>primarykey</Type>
           <Name>examplepublisherprefix_examplecustomentityid</Name>
           <LogicalName>examplepublisherprefix_examplecustomentityid</LogicalName>
@@ -582,7 +582,7 @@
           <ValidForReadApi>1</ValidForReadApi>
           <ValidForCreateApi>0</ValidForCreateApi>
           <IsCustomField>0</IsCustomField>
-          <IsAuditEnabled>0</IsAuditEnabled>
+          <IsAuditEnabled>1</IsAuditEnabled>
           <IsSecured>0</IsSecured>
           <IntroducedVersion>1.0</IntroducedVersion>
           <IsCustomizable>1</IsCustomizable>

--- a/src/Dataverse/templates/pp-plugin-assembly-step/.template.scripts/CopyStep.ps1
+++ b/src/Dataverse/templates/pp-plugin-assembly-step/.template.scripts/CopyStep.ps1
@@ -1,10 +1,9 @@
 $sourcePath = "./.template.temp/__step-id__.xml"
 $targetDir = "./SolutionDeclarationsRoot/SdkMessageProcessingSteps"
-
-mkdir "SolutionDeclarationsRoot/SdkMessageProcessingSteps"
+$targetFile = Join-Path $targetDir "{__step-id__}.xml"
 
 if (!(Test-Path $targetDir)) {
     New-Item -ItemType Directory -Path $targetDir -Force
 }
 
-Copy-Item $sourcePath $targetDir -Force
+Copy-Item $sourcePath $targetFile -Force

--- a/src/Dataverse/templates/pp-security-role-privilege/.template.scripts/AddPrivilegesToSecurityRole.ps1
+++ b/src/Dataverse/templates/pp-security-role-privilege/.template.scripts/AddPrivilegesToSecurityRole.ps1
@@ -15,17 +15,30 @@ $wrapped = "<RolePrivileges>$privilegesRaw</RolePrivileges>"
 
 foreach ($privilege in $newPrivilegesXml.RolePrivileges.ChildNodes) {
     $imported = $entityXml.ImportNode($privilege, $true)
-    $rolePrivilegesNode.AppendChild($imported) | Out-Null
-}
+    $newName = $imported.GetAttribute('name')
 
-# Sort all RolePrivilege elements alphabetically by name attribute
-$allPrivileges = @($rolePrivilegesNode.SelectNodes('RolePrivilege'))
-$sorted = $allPrivileges | Sort-Object { $_.GetAttribute('name') }
+    # Skip if privilege already exists (idempotency)
+    $existing = $rolePrivilegesNode.SelectSingleNode("RolePrivilege[@name='$newName']")
+    if ($existing) {
+        # Update level if different
+        $existing.SetAttribute('level', $imported.GetAttribute('level'))
+        continue
+    }
 
-# Remove all existing privileges and re-add in sorted order
-$rolePrivilegesNode.RemoveAll()
-foreach ($priv in $sorted) {
-    $rolePrivilegesNode.AppendChild($priv) | Out-Null
+    # Insert in alphabetical order by name
+    $insertBefore = $null
+    foreach ($child in $rolePrivilegesNode.SelectNodes('RolePrivilege')) {
+        if ($child.GetAttribute('name') -gt $newName) {
+            $insertBefore = $child
+            break
+        }
+    }
+
+    if ($insertBefore) {
+        $rolePrivilegesNode.InsertBefore($imported, $insertBefore) | Out-Null
+    } else {
+        $rolePrivilegesNode.AppendChild($imported) | Out-Null
+    }
 }
 
 $settings = New-Object System.Xml.XmlWriterSettings

--- a/src/Dataverse/templates/pp-security-role-privilege/.template.scripts/AddPrivilegesToSecurityRole.ps1
+++ b/src/Dataverse/templates/pp-security-role-privilege/.template.scripts/AddPrivilegesToSecurityRole.ps1
@@ -18,6 +18,16 @@ foreach ($privilege in $newPrivilegesXml.RolePrivileges.ChildNodes) {
     $rolePrivilegesNode.AppendChild($imported) | Out-Null
 }
 
+# Sort all RolePrivilege elements alphabetically by name attribute
+$allPrivileges = @($rolePrivilegesNode.SelectNodes('RolePrivilege'))
+$sorted = $allPrivileges | Sort-Object { $_.GetAttribute('name') }
+
+# Remove all existing privileges and re-add in sorted order
+$rolePrivilegesNode.RemoveAll()
+foreach ($priv in $sorted) {
+    $rolePrivilegesNode.AppendChild($priv) | Out-Null
+}
+
 $settings = New-Object System.Xml.XmlWriterSettings
 $settings.Indent = $true
 $settings.NewLineHandling = [System.Xml.NewLineHandling]::None

--- a/src/Dataverse/templates/pp-security-role-privilege/.template.scripts/AddPrivilegesToSecurityRole.ps1
+++ b/src/Dataverse/templates/pp-security-role-privilege/.template.scripts/AddPrivilegesToSecurityRole.ps1
@@ -28,7 +28,7 @@ foreach ($privilege in $newPrivilegesXml.RolePrivileges.ChildNodes) {
     # Insert in alphabetical order by name
     $insertBefore = $null
     foreach ($child in $rolePrivilegesNode.SelectNodes('RolePrivilege')) {
-        if ($child.GetAttribute('name') -gt $newName) {
+        if ([string]::Compare($child.GetAttribute('name'), $newName, [StringComparison]::OrdinalIgnoreCase) -gt 0) {
             $insertBefore = $child
             break
         }

--- a/src/Dataverse/templates/pp-solution/.template.config/template.json
+++ b/src/Dataverse/templates/pp-solution/.template.config/template.json
@@ -132,6 +132,21 @@
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
       "args": {
         "executable": "pwsh",
+        "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/NormalizeNilTags.ps1\"",
+        "redirectStandardOutput": "false"
+      },
+      "manualInstructions": [
+        {
+          "text": "Normalize nil XML tags to single-line format"
+        }
+      ],
+      "continueOnError": true,
+      "description": "Normalize nil XML tags to match SolutionPackager export format"
+    },
+    {
+      "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
+      "args": {
+        "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/Cleanup.ps1\"",
         "redirectStandardOutput": "false"
       },

--- a/src/Dataverse/templates/pp-solution/.template.scripts/NormalizeNilTags.ps1
+++ b/src/Dataverse/templates/pp-solution/.template.scripts/NormalizeNilTags.ps1
@@ -1,8 +1,26 @@
-$solutionXmlPath = (Resolve-Path 'SolutionDeclarationsRoot/Other/Solution.xml').Path
-$content = Get-Content -Path $solutionXmlPath -Raw
+# Find Solution.xml — may be in SolutionDeclarationsRoot/Other or Other depending on flattening
+$candidates = @(
+    'SolutionDeclarationsRoot/Other/Solution.xml',
+    'Other/Solution.xml'
+)
 
-# Collapse nil tags that the template engine splits across lines:
+$solutionXmlPath = $null
+foreach ($c in $candidates) {
+    if (Test-Path $c) {
+        $solutionXmlPath = (Resolve-Path $c).Path
+        break
+    }
+}
+
+if (-not $solutionXmlPath) {
+    Write-Warning "Solution.xml not found, skipping nil tag normalization"
+    exit 0
+}
+
+$content = [System.IO.File]::ReadAllText($solutionXmlPath)
+
+# Collapse nil tags split across lines by template engine:
 #   <Tag xsi:nil="true">\n      </Tag>  →  <Tag xsi:nil="true"></Tag>
-$content = [regex]::Replace($content, '(xsi:nil="true")>\s*\n\s*</', '$1></')
+$content = [regex]::Replace($content, '(xsi:nil="true")>\s*\r?\n\s*</', '$1></')
 
 [System.IO.File]::WriteAllText($solutionXmlPath, $content)

--- a/src/Dataverse/templates/pp-solution/.template.scripts/NormalizeNilTags.ps1
+++ b/src/Dataverse/templates/pp-solution/.template.scripts/NormalizeNilTags.ps1
@@ -1,0 +1,8 @@
+$solutionXmlPath = (Resolve-Path 'SolutionDeclarationsRoot/Other/Solution.xml').Path
+$content = Get-Content -Path $solutionXmlPath -Raw
+
+# Collapse nil tags that the template engine splits across lines:
+#   <Tag xsi:nil="true">\n      </Tag>  →  <Tag xsi:nil="true"></Tag>
+$content = [regex]::Replace($content, '(xsi:nil="true")>\s*\n\s*</', '$1></')
+
+[System.IO.File]::WriteAllText($solutionXmlPath, $content)

--- a/src/Dataverse/templates/pp-solution/.template.scripts/NormalizeNilTags.ps1
+++ b/src/Dataverse/templates/pp-solution/.template.scripts/NormalizeNilTags.ps1
@@ -1,26 +1,13 @@
-# Find Solution.xml — may be in SolutionDeclarationsRoot/Other or Other depending on flattening
-$candidates = @(
-    'SolutionDeclarationsRoot/Other/Solution.xml',
-    'Other/Solution.xml'
-)
+# Normalize nil XML tags to match SolutionPackager export format
+# Template engine splits <Tag xsi:nil="true"></Tag> across two lines
 
-$solutionXmlPath = $null
-foreach ($c in $candidates) {
-    if (Test-Path $c) {
-        $solutionXmlPath = (Resolve-Path $c).Path
-        break
-    }
-}
+$solutionXml = Get-ChildItem -Path . -Filter Solution.xml -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
 
-if (-not $solutionXmlPath) {
+if (-not $solutionXml) {
     Write-Warning "Solution.xml not found, skipping nil tag normalization"
     exit 0
 }
 
-$content = [System.IO.File]::ReadAllText($solutionXmlPath)
-
-# Collapse nil tags split across lines by template engine:
-#   <Tag xsi:nil="true">\n      </Tag>  →  <Tag xsi:nil="true"></Tag>
+$content = [System.IO.File]::ReadAllText($solutionXml.FullName)
 $content = [regex]::Replace($content, '(xsi:nil="true")>\s*\r?\n\s*</', '$1></')
-
-[System.IO.File]::WriteAllText($solutionXmlPath, $content)
+[System.IO.File]::WriteAllText($solutionXml.FullName, $content)

--- a/src/Dataverse/templates/pp-solution/SolutionDeclarationsRoot/Other/Customizations.xml
+++ b/src/Dataverse/templates/pp-solution/SolutionDeclarationsRoot/Other/Customizations.xml
@@ -10,7 +10,6 @@
   <OrganizationSettings />
   <optionsets />
   <CustomControls />
-  <SolutionPluginAssemblies />
   <EntityDataProviders />
   <Languages>
     <Language>1033</Language>

--- a/src/Dataverse/templates/pp-solution/SolutionDeclarationsRoot/Other/Solution.xml
+++ b/src/Dataverse/templates/pp-solution/SolutionDeclarationsRoot/Other/Solution.xml
@@ -1,90 +1,81 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ImportExportXml version="9.1.0.643" SolutionPackageVersion="9.1" languagecode="1033" generatedBy="CrmLive" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <SolutionManifest>
-    <!-- Unique Name of Cds Solution-->
     <UniqueName>SolutionLogicalNameExample</UniqueName>
     <LocalizedNames>
-      <!-- Localized Solution Name in language code -->
       <LocalizedName description="SolutionLogicalNameExample" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
     <Version>1.0</Version>
-    <!-- Solution Package Type: Unmanaged(0)/Managed(1)/Both(2)-->
     <Managed>2</Managed>
     <Publisher>
-      <!-- Unique Publisher Name of Cds Solution -->
       <UniqueName>examplepublisher</UniqueName>
       <LocalizedNames>
-        <!-- Localized Cds Publisher Name in language code-->
         <LocalizedName description="examplepublisher" languagecode="1033" />
       </LocalizedNames>
       <Descriptions>
-        <!-- Description of Cds Publisher in language code -->
         <Description description="examplepublisher" languagecode="1033" />
       </Descriptions>
-      <EMailAddress xsi:nil="true" />
-      <SupportingWebsiteUrl xsi:nil="true" />
-      <!-- Customization Prefix for the Cds Publisher-->
+      <EMailAddress xsi:nil="true"></EMailAddress>
+      <SupportingWebsiteUrl xsi:nil="true"></SupportingWebsiteUrl>
       <CustomizationPrefix>examplepublisherprefix</CustomizationPrefix>
-      <!-- Derived Option Value Prefix for the Customization Prefix of Cds Publisher -->
       <CustomizationOptionValuePrefix>36171</CustomizationOptionValuePrefix>
       <Addresses>
-        <!-- Address of the Publisher-->
         <Address>
           <AddressNumber>1</AddressNumber>
           <AddressTypeCode>1</AddressTypeCode>
-          <City xsi:nil="true" />
-          <County xsi:nil="true" />
-          <Country xsi:nil="true" />
-          <Fax xsi:nil="true" />
-          <FreightTermsCode xsi:nil="true" />
-          <ImportSequenceNumber xsi:nil="true" />
-          <Latitude xsi:nil="true" />
-          <Line1 xsi:nil="true" />
-          <Line2 xsi:nil="true" />
-          <Line3 xsi:nil="true" />
-          <Longitude xsi:nil="true" />
-          <Name xsi:nil="true" />
-          <PostalCode xsi:nil="true" />
-          <PostOfficeBox xsi:nil="true" />
-          <PrimaryContactName xsi:nil="true" />
+          <City xsi:nil="true"></City>
+          <County xsi:nil="true"></County>
+          <Country xsi:nil="true"></Country>
+          <Fax xsi:nil="true"></Fax>
+          <FreightTermsCode xsi:nil="true"></FreightTermsCode>
+          <ImportSequenceNumber xsi:nil="true"></ImportSequenceNumber>
+          <Latitude xsi:nil="true"></Latitude>
+          <Line1 xsi:nil="true"></Line1>
+          <Line2 xsi:nil="true"></Line2>
+          <Line3 xsi:nil="true"></Line3>
+          <Longitude xsi:nil="true"></Longitude>
+          <Name xsi:nil="true"></Name>
+          <PostalCode xsi:nil="true"></PostalCode>
+          <PostOfficeBox xsi:nil="true"></PostOfficeBox>
+          <PrimaryContactName xsi:nil="true"></PrimaryContactName>
           <ShippingMethodCode>1</ShippingMethodCode>
-          <StateOrProvince xsi:nil="true" />
-          <Telephone1 xsi:nil="true" />
-          <Telephone2 xsi:nil="true" />
-          <Telephone3 xsi:nil="true" />
-          <TimeZoneRuleVersionNumber xsi:nil="true" />
-          <UPSZone xsi:nil="true" />
-          <UTCOffset xsi:nil="true" />
-          <UTCConversionTimeZoneCode xsi:nil="true" />
+          <StateOrProvince xsi:nil="true"></StateOrProvince>
+          <Telephone1 xsi:nil="true"></Telephone1>
+          <Telephone2 xsi:nil="true"></Telephone2>
+          <Telephone3 xsi:nil="true"></Telephone3>
+          <TimeZoneRuleVersionNumber xsi:nil="true"></TimeZoneRuleVersionNumber>
+          <UPSZone xsi:nil="true"></UPSZone>
+          <UTCOffset xsi:nil="true"></UTCOffset>
+          <UTCConversionTimeZoneCode xsi:nil="true"></UTCConversionTimeZoneCode>
         </Address>
         <Address>
           <AddressNumber>2</AddressNumber>
           <AddressTypeCode>1</AddressTypeCode>
-          <City xsi:nil="true" />
-          <County xsi:nil="true" />
-          <Country xsi:nil="true" />
-          <Fax xsi:nil="true" />
-          <FreightTermsCode xsi:nil="true" />
-          <ImportSequenceNumber xsi:nil="true" />
-          <Latitude xsi:nil="true" />
-          <Line1 xsi:nil="true" />
-          <Line2 xsi:nil="true" />
-          <Line3 xsi:nil="true" />
-          <Longitude xsi:nil="true" />
-          <Name xsi:nil="true" />
-          <PostalCode xsi:nil="true" />
-          <PostOfficeBox xsi:nil="true" />
-          <PrimaryContactName xsi:nil="true" />
+          <City xsi:nil="true"></City>
+          <County xsi:nil="true"></County>
+          <Country xsi:nil="true"></Country>
+          <Fax xsi:nil="true"></Fax>
+          <FreightTermsCode xsi:nil="true"></FreightTermsCode>
+          <ImportSequenceNumber xsi:nil="true"></ImportSequenceNumber>
+          <Latitude xsi:nil="true"></Latitude>
+          <Line1 xsi:nil="true"></Line1>
+          <Line2 xsi:nil="true"></Line2>
+          <Line3 xsi:nil="true"></Line3>
+          <Longitude xsi:nil="true"></Longitude>
+          <Name xsi:nil="true"></Name>
+          <PostalCode xsi:nil="true"></PostalCode>
+          <PostOfficeBox xsi:nil="true"></PostOfficeBox>
+          <PrimaryContactName xsi:nil="true"></PrimaryContactName>
           <ShippingMethodCode>1</ShippingMethodCode>
-          <StateOrProvince xsi:nil="true" />
-          <Telephone1 xsi:nil="true" />
-          <Telephone2 xsi:nil="true" />
-          <Telephone3 xsi:nil="true" />
-          <TimeZoneRuleVersionNumber xsi:nil="true" />
-          <UPSZone xsi:nil="true" />
-          <UTCOffset xsi:nil="true" />
-          <UTCConversionTimeZoneCode xsi:nil="true" />
+          <StateOrProvince xsi:nil="true"></StateOrProvince>
+          <Telephone1 xsi:nil="true"></Telephone1>
+          <Telephone2 xsi:nil="true"></Telephone2>
+          <Telephone3 xsi:nil="true"></Telephone3>
+          <TimeZoneRuleVersionNumber xsi:nil="true"></TimeZoneRuleVersionNumber>
+          <UPSZone xsi:nil="true"></UPSZone>
+          <UTCOffset xsi:nil="true"></UTCOffset>
+          <UTCConversionTimeZoneCode xsi:nil="true"></UTCConversionTimeZoneCode>
         </Address>
       </Addresses>
     </Publisher>


### PR DESCRIPTION
## Problem

When scaffolding a solution with templates and then exporting it from the environment, the roundtrip produces unnecessary diffs due to formatting differences between the templates and SolutionPackager output.

## Changes

### Solution.xml formatting (commit 1)
- Remove XML comments (SolutionPackager strips them on export)
- Use explicit close tags for nil elements (`<EMailAddress xsi:nil="true"></EMailAddress>`)

### Cross-template alignment (commit 2)
- Convert Entity.xml from CRLF to LF line endings
- Wrap step XML filename GUID in braces (`{guid}.xml`) via CopyStep.ps1
- Sort security role privileges alphabetically by `name` attribute (sorted insertion with dedup)
- Reorder Entity.xml attributes: system first, then custom (alphabetically)

### Improved privilege sorting (commit 3)
- Replace fragile `RemoveAll` + re-add with sorted insertion
- Deduplication: if privilege exists, updates level instead of duplicating
- Idempotent: safe to run template multiple times

### Entity attribute sort post-action (commit 4)
- Add `SortEntityAttributes.ps1` to both `pp-entity` and `pp-entity-attribute`
- Sorts `<attribute>` elements by `PhysicalName` (case-insensitive) to match SolutionPackager export
- Runs as post-action so it handles any publisher prefix correctly after token replacement
- Registered in both templates so new attributes added later also get sorted

### Why `<Managed>2</Managed>` is kept
Decompiling `SolutionPackagerLib.dll` (v2.6.4) confirmed that `<Managed>2</Managed>` (Both) is required in legacy XML format to allow packing as either Managed or Unmanaged. Changing to `0` would block `--packagetype Managed`.

### What's NOT changed
- Entity.xml server-enriched metadata (added on export)
- SavedQuery attribute ordering (server-determined)
- System relationships (added by server on entity creation)
- Version numbers (server-specific)