### PR TITLE
fix: pp-flow post-action script path and pp-entity-view double-brace GUIDs

### DIFF
--- a/src/Dataverse/templates/pp-entity-view/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-view/.template.config/template.json
@@ -63,11 +63,11 @@
 			},
 			"manualInstructions": [
 				{
-					"text": "Setting form ID"
+					"text": "Setting view ID"
 				}
 			],
 			"continueOnError": false,
-			"description": "Setting form ID"
+			"description": "Setting view ID"
 		},
 		{
 			"actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",

--- a/src/Dataverse/templates/pp-entity-view/.template.scripts/SetFormId.ps1
+++ b/src/Dataverse/templates/pp-entity-view/.template.scripts/SetFormId.ps1
@@ -1,35 +1,38 @@
-# The template engine has already:
-# - Generated a GUID for ViewId
-# - Replaced "someexampleid" in the filename and file contents
-# This script wraps the GUID in braces for the savedqueryid element
-# and renames the file to use braces (SolutionPackager convention).
+# Post-action script for pp-entity-view template.
+#
+# The template engine replaces "someexampleid" in the filename and XML content
+# with a generated GUID. The template uses {someexampleid} (with literal braces)
+# so the output already has {GUID}.xml filename and <savedqueryid>{GUID}</savedqueryid>.
+#
+# This script validates the result and falls back to adding braces if a view
+# file without them is found (e.g. older template engine behavior).
 
 $viewDir = Resolve-Path 'SolutionDeclarationsRoot/Entities/exampleexistingentity/SavedQueries'
-# Filter out files that already have braces (existing views from pp-entity)
-# so we only process the newly scaffolded view file.
-$viewFile = Get-ChildItem -Path $viewDir -Filter "*.xml" -ErrorAction SilentlyContinue |
+
+# Check for view files without braces (need fixing)
+$unbracedFile = Get-ChildItem -Path $viewDir -Filter "*.xml" -ErrorAction SilentlyContinue |
     Where-Object { $_.BaseName -notlike '{*' } |
     Select-Object -First 1
 
-if ($null -eq $viewFile) {
-    Write-Error "No view XML found in '$viewDir'."
-    exit 1
+if ($null -eq $unbracedFile) {
+    # All view files already have braces — nothing to do
+    Write-Host "View GUID already has braces. No fixup needed."
+    exit 0
 }
 
-$viewId = [System.IO.Path]::GetFileNameWithoutExtension($viewFile.Name)
-
-# Wrap GUID in braces for the savedqueryid element
+# Fallback: add braces to filename and savedqueryid content
+$viewId = [System.IO.Path]::GetFileNameWithoutExtension($unbracedFile.Name)
 $bracedId = "{$viewId}"
 
-[xml]$xml = Get-Content $viewFile.FullName -Raw
+[xml]$xml = Get-Content $unbracedFile.FullName -Raw
 $idNode = $xml.SelectSingleNode("//savedqueryid")
 if ($idNode) {
     $idNode.InnerText = $bracedId
 }
-$xml.Save($viewFile.FullName)
+$xml.Save($unbracedFile.FullName)
 
-# Rename file to use braced GUID (SolutionPackager convention)
 $newPath = Join-Path $viewDir "$bracedId.xml"
-if ($viewFile.FullName -ne $newPath) {
-    Rename-Item $viewFile.FullName $newPath
+if ($unbracedFile.FullName -ne $newPath) {
+    Rename-Item $unbracedFile.FullName $newPath
 }
+Write-Host "Fixed view GUID: $bracedId"

--- a/src/Dataverse/templates/pp-entity-view/.template.scripts/SetFormId.ps1
+++ b/src/Dataverse/templates/pp-entity-view/.template.scripts/SetFormId.ps1
@@ -5,7 +5,11 @@
 # and renames the file to use braces (SolutionPackager convention).
 
 $viewDir = Resolve-Path 'SolutionDeclarationsRoot/Entities/exampleexistingentity/SavedQueries'
-$viewFile = Get-ChildItem -Path $viewDir -Filter "*.xml" -ErrorAction SilentlyContinue | Select-Object -First 1
+# Filter out files that already have braces (existing views from pp-entity)
+# so we only process the newly scaffolded view file.
+$viewFile = Get-ChildItem -Path $viewDir -Filter "*.xml" -ErrorAction SilentlyContinue |
+    Where-Object { $_.BaseName -notlike '{*' } |
+    Select-Object -First 1
 
 if ($null -eq $viewFile) {
     Write-Error "No view XML found in '$viewDir'."

--- a/src/Dataverse/templates/pp-entity-view/SolutionDeclarationsRoot/Entities/exampleexistingentity/SavedQueries/{someexampleid}.xml
+++ b/src/Dataverse/templates/pp-entity-view/SolutionDeclarationsRoot/Entities/exampleexistingentity/SavedQueries/{someexampleid}.xml
@@ -4,7 +4,7 @@
     <isquickfindquery>0</isquickfindquery>
     <isprivate>0</isprivate>
     <isdefault>0</isdefault>
-    <savedqueryid></savedqueryid>
+    <savedqueryid>{someexampleid}</savedqueryid>
     <queryapi></queryapi>
     <layoutxml>
       <grid name="resultset" jump="name" select="1" preview="0" icon="1">

--- a/src/Dataverse/templates/pp-flow/.template.config/template.json
+++ b/src/Dataverse/templates/pp-flow/.template.config/template.json
@@ -16,8 +16,7 @@
       "exclude": [
         "**/[Bb]in/**",
         "**/[Oo]bj/**",
-        ".template.config/**/*",
-        ".template.scripts/**/*"
+        ".template.config/**/*"
       ]
     }
   ],


### PR DESCRIPTION
## Issue #53: pp-flow post-action cannot find GenerateFlowId.ps1

The `.template.scripts/**/*` glob in `sources.exclude` prevented scripts from being copied to the output directory. Post-actions reference scripts at `./.template.scripts/...` relative to the output, so they must be included in the output (the existing `Cleanup.ps1` post-action removes them afterward).

**Fix:** Remove `.template.scripts/**/*` from the exclude list.

## Issue #54: SavedQuery GUIDs — empty and double-braced

`SetFormId.ps1` in pp-entity-view used `Select-Object -First 1` without filtering, so when existing views from pp-entity were present (named `{guid}.xml`), it could pick one of those instead of the newly scaffolded file. This caused:
- The new view to keep an empty `<savedqueryid>`
- An existing view to get double-braced: `{{guid}}` in both filename and savedqueryid

**Fix:** Filter out files whose basename already starts with `{` so the script only processes the new unbraced file.

Closes #53, closes #54