### PR TITLE
fix: pp-solution handles missing .sln gracefully

### DIFF
--- a/src/Dataverse/templates/pp-solution/.template.config/template.json
+++ b/src/Dataverse/templates/pp-solution/.template.config/template.json
@@ -110,7 +110,7 @@
         "inRoot": true
       },
       "actionId": "D396686C-DE0E-4DE6-906D-291CD29FC5DE",
-      "continueOnError": false,
+      "continueOnError": true,
       "primaryOutputIndexes": "0"
     },
     {


### PR DESCRIPTION
Fixes #52.

The `addProjectsToSolutionFile` post-action in the `pp-solution` template fails with "Unable to determine which solution file to add the reference to" when scaffolding into a workspace without a `.sln`/`.slnx` file.

**Fix:** Set `continueOnError: true` on the post-action so it warns instead of reporting failure. The `manualInstructions` fallback was already in place.