### PR TITLE
feat: add Autonumber, RichText, and Money AccuracySource to pp-entity-attribute

### DIFF
--- a/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
@@ -102,7 +102,7 @@
     },
     "AutonumberFormat": {
       "type": "parameter",
-      "description": "[Autonumber] Format string for auto-numbered fields (e.g., INV-{SEQNUM:5}-{DATEFMT:yyyyMMdd}).",
+      "description": "[Autonumber] Format string using {SEQNUM:N}, {RANDSTRING:N}, {DATETIMEUTC:format} placeholders (e.g., INV-{SEQNUM:5}-{DATETIMEUTC:yyyyMMdd}).",
       "datatype": "text",
       "defaultValue": "{SEQNUM:5}",
       "isEnabled": "(AttributeType == \"Autonumber\")",

--- a/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
@@ -52,6 +52,7 @@
       "choices": [
         { "choice": "Text", "description": "Single line of text (nvarchar)" },
         { "choice": "MultilineText", "description": "Multiple lines of text (ntext/memo)" },
+        { "choice": "Autonumber", "description": "Auto-numbered text field (nvarchar)" },
         { "choice": "WholeNumber", "description": "Whole number (int)" },
         { "choice": "Decimal", "description": "Decimal number" },
         { "choice": "Float", "description": "Floating point number" },
@@ -83,8 +84,29 @@
         { "choice": "url", "description": "URL" },
         { "choice": "phone", "description": "Phone number" },
         { "choice": "tickersymbol", "description": "Ticker symbol" },
-        { "choice": "textarea", "description": "Text area" }
+        { "choice": "textarea", "description": "Text area" },
+        { "choice": "richtext", "description": "Rich text with HTML editor" }
       ]
+    },
+    "MemoFormat": {
+      "type": "parameter",
+      "description": "[MultilineText] Format for multi-line text fields.",
+      "datatype": "choice",
+      "defaultValue": "text",
+      "isEnabled": "(AttributeType == \"MultilineText\")",
+      "replaces": "__memo-format__",
+      "choices": [
+        { "choice": "text", "description": "Plain text" },
+        { "choice": "richtext", "description": "Rich text with HTML editor" }
+      ]
+    },
+    "AutonumberFormat": {
+      "type": "parameter",
+      "description": "[Autonumber] Format string for auto-numbered fields (e.g., INV-{SEQNUM:5}-{DATEFMT:yyyyMMdd}).",
+      "datatype": "text",
+      "defaultValue": "{SEQNUM:5}",
+      "isEnabled": "(AttributeType == \"Autonumber\")",
+      "replaces": "__autonumber-format__"
     },
     "WholeNumberFormat": {
       "type": "parameter",
@@ -241,7 +263,7 @@
       "datatype": "int",
       "defaultValue": 100,
       "replaces": "__max-length__",
-      "isEnabled": "(AttributeType == \"Text\")",
+      "isEnabled": "(AttributeType == \"Text\" || AttributeType == \"Autonumber\")",
       "description": "[Text] Maximum character length for single-line text (default: 100)."
     },
     "MemoMaxLength": {
@@ -291,6 +313,19 @@
       "replaces": "__max-value-money__",
       "isEnabled": "(AttributeType == \"Money\")",
       "description": "[Money] Maximum allowed value (default: 922337203685477)."
+    },
+    "MoneyAccuracySource": {
+      "type": "parameter",
+      "description": "[Money] Precision source: 0=use attribute Precision value, 1=use organization pricing precision, 2=use currency precision.",
+      "datatype": "choice",
+      "defaultValue": "2",
+      "isEnabled": "(AttributeType == \"Money\")",
+      "replaces": "__accuracy-source__",
+      "choices": [
+        { "choice": "0", "description": "Attribute precision (use DecimalPrecision value)" },
+        { "choice": "1", "description": "Organization pricing precision" },
+        { "choice": "2", "description": "Currency precision (default)" }
+      ]
     },
     "WholeNumberMinValue": {
       "type": "parameter",

--- a/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
@@ -46,29 +46,29 @@
     },
     "AttributeType": {
       "type": "parameter",
-      "description": "Data type of the attribute",
+      "description": "Data type of the column. Each type enables a specific set of type-prefixed parameters (e.g., Text enables TextFormat and TextMaxLength; Money enables MoneyAccuracySource, MoneyMinValue, MoneyMaxValue, and DecimalPrecision).",
       "datatype": "choice",
       "isRequired": true,
       "choices": [
-        { "choice": "Text", "description": "Single line of text (nvarchar)" },
-        { "choice": "MultilineText", "description": "Multiple lines of text (ntext/memo)" },
-        { "choice": "Autonumber", "description": "Auto-numbered text field (nvarchar)" },
-        { "choice": "WholeNumber", "description": "Whole number (int)" },
-        { "choice": "Decimal", "description": "Decimal number" },
-        { "choice": "Float", "description": "Floating point number" },
-        { "choice": "Money", "description": "Currency with base field and support columns" },
-        { "choice": "DateTime", "description": "Date and time" },
-        { "choice": "Boolean", "description": "Yes/No (bit)" },
-        { "choice": "Lookup", "description": "Lookup to another entity" },
-        { "choice": "Customer", "description": "Customer lookup (Account/Contact)" },
-        { "choice": "OptionSet(Local)", "description": "Local choice (single select)" },
-        { "choice": "OptionSet(Global)", "description": "Global choice (single select)" },
-        { "choice": "OptionSet(LocalMulti)", "description": "Local choice (multi select)" },
-        { "choice": "OptionSet(GlobalMulti)", "description": "Global choice (multi select)" },
-        { "choice": "File", "description": "File attachment" },
-        { "choice": "Image", "description": "Image" },
-        { "choice": "BigInt", "description": "Big integer" },
-        { "choice": "JsonText", "description": "Only for Elastic tables" }
+        { "choice": "Text", "description": "Single line of text. Use TextFormat for email/url/phone/richtext variants. Use TextMaxLength for max characters." },
+        { "choice": "MultilineText", "description": "Multiple lines of text (memo). Use MemoFormat for plain text or rich text. Use MemoMaxLength for max characters." },
+        { "choice": "Autonumber", "description": "Auto-numbered text. Use AutonumberFormat with {SEQNUM:N}, {RANDSTRING:N}, {DATETIMEUTC:format} placeholders. Read-only in forms." },
+        { "choice": "WholeNumber", "description": "Whole number (integer). Use WholeNumberFormat for standard/duration/timezone/language/locale variants." },
+        { "choice": "Decimal", "description": "Decimal number. Use DecimalPrecision for decimal places, DecimalMinValue/DecimalMaxValue for range." },
+        { "choice": "Float", "description": "Floating point number. Use DecimalPrecision for decimal places, DecimalMinValue/DecimalMaxValue for range." },
+        { "choice": "Money", "description": "Currency field. Auto-creates _base support column. Use MoneyAccuracySource (0=attribute, 1=org, 2=currency), DecimalPrecision, MoneyMinValue/MoneyMaxValue." },
+        { "choice": "DateTime", "description": "Date and time. Use DateTimeFormat (date/datetime) and DateTimeBehavior (1=UserLocal, 2=DateOnly, 3=TimeZoneIndependent)." },
+        { "choice": "Boolean", "description": "Yes/No field. Use BooleanTrueLabel and BooleanFalseLabel to customize option labels." },
+        { "choice": "Lookup", "description": "Lookup to another entity. Requires LookupTarget (e.g., account). Creates N:1 relationship." },
+        { "choice": "Customer", "description": "Polymorphic lookup targeting Account and Contact. LookupTarget defaults to account." },
+        { "choice": "OptionSet(Local)", "description": "Single-select choice scoped to this entity. Requires OptionSetOptions (e.g., Active:100000000,Inactive:100000001)." },
+        { "choice": "OptionSet(Global)", "description": "Single-select choice shared across entities. Use OptionSetType=New to create or Existing to reference. Requires OptionSetOptions for New." },
+        { "choice": "OptionSet(LocalMulti)", "description": "Multi-select choice scoped to this entity. Requires OptionSetOptions." },
+        { "choice": "OptionSet(GlobalMulti)", "description": "Multi-select choice shared across entities. Use OptionSetType=New or Existing. Requires OptionSetOptions for New." },
+        { "choice": "File", "description": "File attachment column. Use FileMaxSizeInKB for max size (default: 32 MB)." },
+        { "choice": "Image", "description": "Image column. Use ImageMaxSizeInKB for max size (default: 10 MB)." },
+        { "choice": "BigInt", "description": "64-bit integer for large numbers (timestamps, versioning)." },
+        { "choice": "JsonText", "description": "JSON text column. Only valid on Elastic tables." }
       ]
     },
     "TextFormat": {
@@ -171,8 +171,8 @@
       "isEnabled": "(AttributeType == \"OptionSet(Global)\") || (AttributeType == \"OptionSet(GlobalMulti)\")",
       "isRequired": "(AttributeType == \"OptionSet(Global)\") || (AttributeType == \"OptionSet(GlobalMulti)\")",
       "choices": [
-        { "choice": "New" },
-        { "choice": "Existing" }
+        { "choice": "New", "description": "Create a new global option set with the options specified in OptionSetOptions" },
+        { "choice": "Existing", "description": "Reference an existing global option set by name (specify OptionSetName)" }
       ]
     },
     "OptionSetName": {

--- a/src/Dataverse/templates/pp-entity-attribute/.template.temp/attribute.xml
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.temp/attribute.xml
@@ -1,5 +1,5 @@
 <attribute PhysicalName="__attribute-schema-name__">
-    <!--#if (AttributeType == "Text") -->
+    <!--#if (AttributeType == "Text" || AttributeType == "Autonumber") -->
         <Type>nvarchar</Type>
     <!--#elseif (AttributeType == "JsonText") -->
         <Type>nvarchar</Type>
@@ -43,6 +43,8 @@
     <DisplayMask>ValidForForm|ValidForGrid</DisplayMask>
     <!--#elseif (AttributeType == "Image") -->
     <DisplayMask>DenormalizedChild|PrimaryImage|ValidForAdvancedFind|ValidForForm|ValidForGrid</DisplayMask>
+    <!--#elseif (AttributeType == "Autonumber") -->
+    <DisplayMask>ReadOnlyInUI|ValidForAdvancedFind|ValidForForm|ValidForGrid</DisplayMask>
     <!--#else -->
     <DisplayMask>ValidForAdvancedFind|ValidForForm|ValidForGrid</DisplayMask>
     <!--#endif -->
@@ -92,7 +94,11 @@
     <CanModifyIsSortableSettings>1</CanModifyIsSortableSettings>
     <!--#endif -->
     <IsDataSourceSecret>0</IsDataSourceSecret>
+    <!--#if (AttributeType == "Autonumber") -->
+    <AutoNumberFormat>__autonumber-format__</AutoNumberFormat>
+    <!--#else -->
     <AutoNumberFormat></AutoNumberFormat>
+    <!--#endif -->
     <IsSearchable>0</IsSearchable>
     <IsFilterable>0</IsFilterable>
     <IsRetrievable>0</IsRetrievable>
@@ -162,11 +168,15 @@
         <Format>__string-format__</Format>
         <MaxLength>__max-length__</MaxLength>
         <Length>__max-length__</Length>
+    <!--#elseif (AttributeType == "Autonumber") -->
+        <Format>text</Format>
+        <MaxLength>__max-length__</MaxLength>
+        <Length>__max-length__</Length>
     <!--#elseif (AttributeType == "JsonText") -->
         <Format>json</Format>
         <MaxLength>1048576</MaxLength>
     <!--#elseif (AttributeType == "MultilineText") -->
-        <Format>text</Format>
+        <Format>__memo-format__</Format>
         <MaxLength>__max-length-memo__</MaxLength>
     <!--#elseif (AttributeType == "WholeNumber") -->
         <Format>__number-format__</Format>
@@ -184,7 +194,7 @@
         <MinValue>__min-value-money__</MinValue>
         <MaxValue>__max-value-money__</MaxValue>
         <Accuracy>__precision__</Accuracy>
-        <AccuracySource>2</AccuracySource>
+        <AccuracySource>__accuracy-source__</AccuracySource>
     <!--#elseif (AttributeType == "DateTime") -->
         <Format>__datetime-format__</Format>
         <Behavior>__datetime-behavior__</Behavior>


### PR DESCRIPTION
Adds three missing configuration combinations to pp-entity-attribute:

## Autonumber
- New `Autonumber` choice in AttributeType
- `AutonumberFormat` parameter for the format string (e.g., `ORD-{SEQNUM:6}`, `{DATEFMT:yyyyMMdd}-{SEQNUM:4}`, `{RANDSTRING:8}`)
- Emits `ReadOnlyInUI` in DisplayMask (field is system-populated, read-only in forms)
- Seed value is environment-specific and not included in solution XML per [MS docs](https://learn.microsoft.com/en-us/power-apps/maker/data-platform/autonumber-fields)

## Rich Text
- Added `richtext` format to `TextFormat` choices (single-line rich text)
- New `MemoFormat` parameter for MultilineText: `text` (default) or `richtext`
- Enables HTML editor in model-driven apps

## Money AccuracySource
- New `MoneyAccuracySource` parameter with choices:
  - `0` = Use attribute's own DecimalPrecision value
  - `1` = Use organization pricing decimal precision
  - `2` = Use currency precision (default, matches Maker UI)
- Previously hardcoded to `2`

## Validation needed
- [x] Dataverse import/export roundtrip for all three
- [x] CRUD test: create records with autonumber, verify auto-generated values