### PR TITLE
feat: add componentType tags to all templates

### DIFF
--- a/src/Dataverse/templates/pp-api-endpoint/.template.config/template.json
+++ b/src/Dataverse/templates/pp-api-endpoint/.template.config/template.json
@@ -9,7 +9,8 @@
   "sourceName": "pp-api-endpoint",
   "tags": {
     "type": "item",
-    "language": "XML"
+    "language": "XML",
+    "componentType": "CustomAPI"
   },
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-app-code-data/.template.config/template.json
+++ b/src/Dataverse/templates/pp-app-code-data/.template.config/template.json
@@ -9,7 +9,8 @@
   "sourceName": "pp-app-code-data",
   "tags": {
 		"type": "item",
-		"language": "XML"
+		"language": "XML",
+		"componentType": "AppModule"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-app-code-data/.template.config/template.json
+++ b/src/Dataverse/templates/pp-app-code-data/.template.config/template.json
@@ -10,7 +10,6 @@
   "tags": {
 		"type": "item",
 		"language": "XML",
-		"componentType": "AppCodeData"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-app-code-data/.template.config/template.json
+++ b/src/Dataverse/templates/pp-app-code-data/.template.config/template.json
@@ -10,7 +10,7 @@
   "tags": {
 		"type": "item",
 		"language": "XML",
-		"componentType": "AppModule"
+		"componentType": "AppCodeData"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-app-code/.template.config/template.json
+++ b/src/Dataverse/templates/pp-app-code/.template.config/template.json
@@ -10,7 +10,7 @@
   "tags": {
 		"type": "project",
 		"language": "XML",
-		"componentType": "AppModule"
+		"componentType": "AppCode"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-app-code/.template.config/template.json
+++ b/src/Dataverse/templates/pp-app-code/.template.config/template.json
@@ -9,7 +9,8 @@
   "sourceName": "CodeAppExample",
   "tags": {
 		"type": "project",
-		"language": "XML"
+		"language": "XML",
+		"componentType": "AppModule"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-app-code/.template.config/template.json
+++ b/src/Dataverse/templates/pp-app-code/.template.config/template.json
@@ -10,7 +10,7 @@
   "tags": {
 		"type": "project",
 		"language": "XML",
-		"componentType": "AppCode"
+		"componentType": "CodeApp"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-app-model-component/.template.config/template.json
+++ b/src/Dataverse/templates/pp-app-model-component/.template.config/template.json
@@ -10,7 +10,7 @@
   "tags": {
 		"type": "item",
 		"language": "XML",
-		"componentType": "AppModule"
+		"componentType": "AppModuleComponent"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-app-model-component/.template.config/template.json
+++ b/src/Dataverse/templates/pp-app-model-component/.template.config/template.json
@@ -9,7 +9,8 @@
   "sourceName": "App-ModelDriven-component",
   "tags": {
 		"type": "item",
-		"language": "XML"
+		"language": "XML",
+		"componentType": "AppModule"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-app-model/.template.config/template.json
+++ b/src/Dataverse/templates/pp-app-model/.template.config/template.json
@@ -9,7 +9,8 @@
   "sourceName": "App-ModelDriven",
   "tags": {
 		"type": "item",
-		"language": "XML"
+		"language": "XML",
+		"componentType": "AppModule"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-app-security-role/.template.config/template.json
+++ b/src/Dataverse/templates/pp-app-security-role/.template.config/template.json
@@ -9,7 +9,8 @@
   "sourceName": "Role-App",
   "tags": {
 		"type": "item",
-		"language": "XML"
+		"language": "XML",
+		"componentType": "AppModule"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-app-security-role/.template.config/template.json
+++ b/src/Dataverse/templates/pp-app-security-role/.template.config/template.json
@@ -10,7 +10,7 @@
   "tags": {
 		"type": "item",
 		"language": "XML",
-		"componentType": "AppModule"
+		"componentType": "AppSecurityRole"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-bpf-stage-step/.template.config/template.json
+++ b/src/Dataverse/templates/pp-bpf-stage-step/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "XML",
     "type": "item",
-    "componentType": "Workflow"
+    "componentType": "BpfStageStep"
   },
   "sourceName": "SolutionLogicalNameExample",
   "sources": [

--- a/src/Dataverse/templates/pp-bpf-stage-step/.template.config/template.json
+++ b/src/Dataverse/templates/pp-bpf-stage-step/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Adds a step inside a BPF stage: step.xaml (StepComposite + ControlStep) + row.xml (form row with cell and control) + steplabels.xml. Run inside a stage created by pp-bpf-stage.",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "Workflow"
   },
   "sourceName": "SolutionLogicalNameExample",
   "sources": [

--- a/src/Dataverse/templates/pp-bpf-stage/.template.config/template.json
+++ b/src/Dataverse/templates/pp-bpf-stage/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Adds a stage to an existing BPF: stage.xaml (StageComposite XAML) + stageForm.xml (tab with columns/sections) + steplabels.xml. Run inside the BPF project created by pp-bpf.",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "Workflow"
   },
   "sourceName": "SolutionLogicalNameExample",
   "sources": [

--- a/src/Dataverse/templates/pp-bpf-stage/.template.config/template.json
+++ b/src/Dataverse/templates/pp-bpf-stage/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "XML",
     "type": "item",
-    "componentType": "Workflow"
+    "componentType": "BpfStage"
   },
   "sourceName": "SolutionLogicalNameExample",
   "sources": [

--- a/src/Dataverse/templates/pp-bpf/.template.config/template.json
+++ b/src/Dataverse/templates/pp-bpf/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "XML",
     "type": "item",
-    "componentType": "Workflow"
+    "componentType": "BusinessProcessFlow"
   },
   "sourceName": "SolutionLogicalNameExample",
   "sources": [

--- a/src/Dataverse/templates/pp-bpf/.template.config/template.json
+++ b/src/Dataverse/templates/pp-bpf/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Scaffolds a Business Process Flow: Entity.xml (BPF entity with ActiveStageId, Duration etc.) + main form + RibbonDiff.xml + relationship to primary entity + XAML workflow. Add stages with pp-bpf-stage, steps with pp-bpf-stage-step.",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "Workflow"
   },
   "sourceName": "SolutionLogicalNameExample",
   "sources": [

--- a/src/Dataverse/templates/pp-control-parameter/.template.config/template.json
+++ b/src/Dataverse/templates/pp-control-parameter/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Adds XML parameter definitions to a form control. Supports type-specific params: Lookup (filters, views, MRU), OptionSet, SubGrid (records per page, pickers), TextBox, Number, Label, QuickFormCollection. Run inside an existing entity form.",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "CustomControl"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-control-parameter/.template.config/template.json
+++ b/src/Dataverse/templates/pp-control-parameter/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "XML",
     "type": "item",
-    "componentType": "CustomControl"
+    "componentType": "ControlParameter"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Adds a column to an existing entity. Types: Text, MultilineText, WholeNumber, Decimal, Float, Money, DateTime, Boolean, Lookup, Customer, File, Image, BigInt, OptionSet(Local/Global/LocalMulti/GlobalMulti).",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "Attribute"
   },
   "sourceName": "__attribute-logical-name__",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-entity-form/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-form/.template.config/template.json
@@ -8,7 +8,7 @@
 	"tags": {
 		"language": "XML",
 		"type": "item",
-		"componentType": "SystemForm"
+		"componentType": "EntityForm"
 	},
 	"sourceName": "examplecustomentity",
 	"sources": [

--- a/src/Dataverse/templates/pp-entity-form/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-form/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Creates form definitions for an existing entity: mainform.xml + quick form XML + dialogform.xml. Use when pp-entity already exists and you need an additional or replacement form.",
 	"tags": {
 		"language": "XML",
-		"type": "item"
+		"type": "item",
+		"componentType": "SystemForm"
 	},
 	"sourceName": "examplecustomentity",
 	"sources": [

--- a/src/Dataverse/templates/pp-entity-view/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-view/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Adds a SavedQuery (view) XML for an existing entity. Includes fetchxml, grid layout, column definitions. queryType=64. Use when adding a new list view to an entity.",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "SavedQuery"
   },
   "sourceName": "customentity",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-entity-view/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-view/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "XML",
     "type": "item",
-    "componentType": "SavedQuery"
+    "componentType": "EntityView"
   },
   "sourceName": "customentity",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-entity/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity/.template.config/template.json
@@ -7,7 +7,8 @@
 	"description": "Defines the database schema for a business object - its attributes (columns), keys and indexes—stores its records (rows), includes the forms, views and charts that display the data, supports binding of validations, rules, workflows and plug-ins that run in the object’s context, and applies role-based security that controls behavior and access across apps and environments.",
 	"tags": {
 		"language": "XML",
-		"type": "item"
+		"type": "item",
+		"componentType": "Entity"
 	},
 	"sourceName": "examplecustomentity",
 	"sources": [

--- a/src/Dataverse/templates/pp-flow/.template.config/template.json
+++ b/src/Dataverse/templates/pp-flow/.template.config/template.json
@@ -9,7 +9,7 @@
   "tags": {
     "language": "JSON",
     "type": "item",
-    "componentType": "Workflow"
+    "componentType": "Flow"
   },
   "preferNameDirectory": true,
   "sources": [

--- a/src/Dataverse/templates/pp-flow/.template.config/template.json
+++ b/src/Dataverse/templates/pp-flow/.template.config/template.json
@@ -8,7 +8,8 @@
   "classifications": ["Dataverse", "Power Platform"],
   "tags": {
     "language": "JSON",
-    "type": "item"
+    "type": "item",
+    "componentType": "Workflow"
   },
   "preferNameDirectory": true,
   "sources": [

--- a/src/Dataverse/templates/pp-form-cell/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-cell/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "HIERARCHY: inside Row (pp-form-row) -> wraps Control (pp-form-control). Generates cell.xml (standard) + dialogcell.xml (dialog). Direct container for a single field label + control.",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "SystemForm"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-form-cell/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-cell/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "XML",
     "type": "item",
-    "componentType": "SystemForm"
+    "componentType": "FormCell"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-form-column/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-column/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "HIERARCHY: inside Tab (pp-form-tab) -> contains Sections (pp-form-section). Generates <column> with percentage width. Divides tab horizontally.",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "SystemForm"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-form-column/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-column/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "XML",
     "type": "item",
-    "componentType": "SystemForm"
+    "componentType": "FormColumn"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-form-control/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-control/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "HIERARCHY: inside Cell (pp-form-cell) -> leaf element. Generates control.xml (standard, 11 types: Text/MultilineText/WholeNumber/Decimal/Float/Currency/DateTime/Lookup/OptionSet/SubGrid/Button, classid auto-calculated) + dialogcontrol.xml (unbound dialog control).",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "SystemForm"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-form-control/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-control/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "XML",
     "type": "item",
-    "componentType": "SystemForm"
+    "componentType": "FormControl"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-form-dialog-tabfooter/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-dialog-tabfooter/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Injects a <tabfooter> XML element into a Dataverse dialog form tab. Use when you need a footer area at the bottom of a dialog tab.",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "SystemForm"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-form-dialog-tabfooter/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-dialog-tabfooter/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "XML",
     "type": "item",
-    "componentType": "SystemForm"
+    "componentType": "FormDialogTabFooter"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-form-event-handler/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-event-handler/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "XML",
     "type": "item",
-    "componentType": "SystemForm"
+    "componentType": "FormEventHandler"
   },
   "sourceName": "formeventexample",
   "sources": [

--- a/src/Dataverse/templates/pp-form-event-handler/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-event-handler/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Registers a JS event handler on a form. No source files \u2014 script-only. Events: onload, onsave, onchange, onclick. Required: FormId, LibraryName, FunctionName, EventType. Injects handler + library reference into form XML.",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "SystemForm"
   },
   "sourceName": "formeventexample",
   "sources": [

--- a/src/Dataverse/templates/pp-form-parameter/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-parameter/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "XML",
     "type": "item",
-    "componentType": "SystemForm"
+    "componentType": "FormParameter"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-form-parameter/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-parameter/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Adds a typed parameter to a form. No source files \u2014 script-only. Types: UniqueId, SafeString, Integer, Boolean, Double, Long, Object. Required: FormId, ParameterLogicalName, ParameterType.",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "SystemForm"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-form-row/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-row/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "HIERARCHY: inside Section (pp-form-section) -> contains Cells (pp-form-cell). Generates empty <row> element. One horizontal line of fields.",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "SystemForm"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-form-row/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-row/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "XML",
     "type": "item",
-    "componentType": "SystemForm"
+    "componentType": "FormRow"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-form-section/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-section/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "XML",
     "type": "item",
-    "componentType": "SystemForm"
+    "componentType": "FormSection"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-form-section/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-section/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "HIERARCHY: inside Column (pp-form-column) -> contains Rows (pp-form-row). Generates <section> with showlabel, showbar, name, labelid. Labeled grouping of fields.",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "SystemForm"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-form-subgrid/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-subgrid/.template.config/template.json
@@ -8,7 +8,7 @@
     "tags": {
         "language": "XML",
         "type": "item",
-        "componentType": "SystemForm"
+        "componentType": "FormSubgrid"
     },
     "sourceName": "subgridconfig",
     "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-form-subgrid/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-subgrid/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Adds a subgrid to a form showing related entity records. Generates row > cell > control. Params: TargetEntityLogicalName, ViewId, RecordsPerPage, EnableQuickFind, EnableViewPicker, EnableChartPicker. Required: FormId, FormType(main/quick), EntityLogicalName, SubgridLabel.",
     "tags": {
         "language": "XML",
-        "type": "item"
+        "type": "item",
+        "componentType": "SystemForm"
     },
     "sourceName": "subgridconfig",
     "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-form-tab/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-tab/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "HIERARCHY: inside Form (pp-entity-form / pp-entity) -> contains Columns (pp-form-column). Generates <tab verticallayout=true> with name, labelid, empty <columns>. Top-level form container. Can remove default tab via parameter.",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "SystemForm"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-form-tab/.template.config/template.json
+++ b/src/Dataverse/templates/pp-form-tab/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "XML",
     "type": "item",
-    "componentType": "SystemForm"
+    "componentType": "FormTab"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-optionset-global/.template.config/template.json
+++ b/src/Dataverse/templates/pp-optionset-global/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Creates a global OptionSet(picklist, IsGlobal=1): optionset XML + optionsetoption.xml. Options populated from comma-separated list. Reference from entity attributes using pp-entity-attribute with AttributeType=OptionSet(Global).",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "OptionSet"
   },
   "sourceName": "examplecustomentityattribute",
   "preferNameDirectory": false,

--- a/src/Dataverse/templates/pp-pcf/.template.config/template.json
+++ b/src/Dataverse/templates/pp-pcf/.template.config/template.json
@@ -9,7 +9,7 @@
   "tags": {
 		"type": "project",
     "language": "XML",
-		"componentType": "CustomControl"
+		"componentType": "PcfControl"
   },
   "sourceName": "examplesourcename",
   "preferNameDirectory": true,

--- a/src/Dataverse/templates/pp-pcf/.template.config/template.json
+++ b/src/Dataverse/templates/pp-pcf/.template.config/template.json
@@ -8,7 +8,8 @@
   "classifications": ["Dataverse", "Power Platform"],
   "tags": {
 		"type": "project",
-    "language": "XML"
+    "language": "XML",
+		"componentType": "CustomControl"
   },
   "sourceName": "examplesourcename",
   "preferNameDirectory": true,

--- a/src/Dataverse/templates/pp-plugin-assembly-step/.template.config/template.json
+++ b/src/Dataverse/templates/pp-plugin-assembly-step/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Creates SdkMessageProcessingStep XML: PluginTypeName (assembly-qualified), SdkMessageId, PrimaryEntity, Stage, Rank, EventHandlerTypeCode=4602, filtering attributes. Generates SdkMessageProcessingSteps/{GUID}.xml. CHAIN: run after pp-solution --GeneratePluginAssembly true + dotnet build. One step per plugin class per message.",
   "tags": {
     "language": "C#",
-    "type": "project"
+    "type": "project",
+    "componentType": "SdkMessageProcessingStep"
   },
   "symbols": {
     "PrimaryEntity": {

--- a/src/Dataverse/templates/pp-plugin-assembly-step/.template.config/template.json
+++ b/src/Dataverse/templates/pp-plugin-assembly-step/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "C#",
     "type": "project",
-    "componentType": "SdkMessageProcessingStep"
+    "componentType": "PluginAssemblyStep"
   },
   "symbols": {
     "PrimaryEntity": {

--- a/src/Dataverse/templates/pp-plugin-assembly/.template.config/template.json
+++ b/src/Dataverse/templates/pp-plugin-assembly/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Registers a plugin assembly in the solution. Script-only. Generates PluginAssemblies/{Name}-{GUID}/*.dll.data.xml. CHAIN: Step 2 \u2014 run in the target solution after pp-plugin. Required before pp-plugin-assembly-step.",
   "tags": {
     "language": "C#",
-    "type": "project"
+    "type": "project",
+    "componentType": "PluginAssembly"
   },
   "symbols": {
     "AssemblyId": {

--- a/src/Dataverse/templates/pp-plugin/.template.config/template.json
+++ b/src/Dataverse/templates/pp-plugin/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "C#",
     "type": "project",
-    "componentType": "PluginAssembly"
+    "componentType": "Plugin"
   },
   "sourceName": "SolutionLogicalNameExample",
   "sources": [

--- a/src/Dataverse/templates/pp-plugin/.template.config/template.json
+++ b/src/Dataverse/templates/pp-plugin/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Creates a Dataverse plugin project: PluginBase.cs (abstract IPlugin with _context, _organizationService, _tracingService, calls abstract OnExecute()). CHAIN: Step 1 \u2014 create project. Then pp-plugin-assembly (step 2) to register assembly in the target solution, then pp-plugin-assembly-step (step 3) to register steps. Individual plugin classes extend PluginBase.cs in the same project.",
   "tags": {
     "language": "C#",
-    "type": "project"
+    "type": "project",
+    "componentType": "PluginAssembly"
   },
   "sourceName": "SolutionLogicalNameExample",
   "sources": [

--- a/src/Dataverse/templates/pp-plugin/.template.config/template.json
+++ b/src/Dataverse/templates/pp-plugin/.template.config/template.json
@@ -8,7 +8,6 @@
   "tags": {
     "language": "C#",
     "type": "project",
-    "componentType": "Plugin"
   },
   "sourceName": "SolutionLogicalNameExample",
   "sources": [

--- a/src/Dataverse/templates/pp-ribbon-button-hide/.template.config/template.json
+++ b/src/Dataverse/templates/pp-ribbon-button-hide/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "XML",
     "type": "item",
-    "componentType": "RibbonCustomization"
+    "componentType": "RibbonButtonHide"
   },
   "sourceName": "examplebuttonname",
   "sources": [

--- a/src/Dataverse/templates/pp-ribbon-button-hide/.template.config/template.json
+++ b/src/Dataverse/templates/pp-ribbon-button-hide/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Hides an existing ribbon button via HideCustomAction XML. Generates customactionstohide.xml with conditional blocks per button type (e.g. NewRecord at Mscrm.HomepageGrid.{entity}.NewRecord). Injected into entity RibbonDiff.xml.",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "RibbonCustomization"
   },
   "sourceName": "examplebuttonname",
   "sources": [

--- a/src/Dataverse/templates/pp-ribbon-button/.template.config/template.json
+++ b/src/Dataverse/templates/pp-ribbon-button/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Adds a ribbon button: commanddefinition.xml (JavaScriptFunction + $webresource ref) + customaction.xml (location, icons 16x32, sequence, TemplateAlias) + loclbels.xml (Alt, LabelText, ToolTipTitle, ToolTipDescription, LCID 1033). Injected into entity RibbonDiff.xml.",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "RibbonCustomization"
   },
   "sourceName": "examplebuttonname",
   "sources": [

--- a/src/Dataverse/templates/pp-ribbon-button/.template.config/template.json
+++ b/src/Dataverse/templates/pp-ribbon-button/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "XML",
     "type": "item",
-    "componentType": "RibbonCustomization"
+    "componentType": "RibbonButton"
   },
   "sourceName": "examplebuttonname",
   "sources": [

--- a/src/Dataverse/templates/pp-ribbon-command-parameter/.template.config/template.json
+++ b/src/Dataverse/templates/pp-ribbon-command-parameter/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Adds a parameter to a ribbon command. Types: CrmParameter(SelectedControl), CrmParameter(PrimaryControl), StringParameter. Injected into command definition in RibbonDiff.xml.",
   "tags": {
     "language": "XML",
-    "type": "item"
+    "type": "item",
+    "componentType": "RibbonCustomization"
   },
   "sourceName": "examplebuttonname",
   "sources": [

--- a/src/Dataverse/templates/pp-ribbon-command-parameter/.template.config/template.json
+++ b/src/Dataverse/templates/pp-ribbon-command-parameter/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "XML",
     "type": "item",
-    "componentType": "RibbonCustomization"
+    "componentType": "RibbonCommandParameter"
   },
   "sourceName": "examplebuttonname",
   "sources": [

--- a/src/Dataverse/templates/pp-script-library/.template.config/template.json
+++ b/src/Dataverse/templates/pp-script-library/.template.config/template.json
@@ -9,7 +9,7 @@
   "tags": {
     "language": "javascript",
     "type": "project",
-    "componentType": "WebResource"
+    "componentType": "ScriptLibrary"
   },
   "sourceName": "examplesourcename",
   "preferNameDirectory": true,

--- a/src/Dataverse/templates/pp-script-library/.template.config/template.json
+++ b/src/Dataverse/templates/pp-script-library/.template.config/template.json
@@ -9,7 +9,6 @@
   "tags": {
     "language": "javascript",
     "type": "project",
-    "componentType": "ScriptLibrary"
   },
   "sourceName": "examplesourcename",
   "preferNameDirectory": true,

--- a/src/Dataverse/templates/pp-script-library/.template.config/template.json
+++ b/src/Dataverse/templates/pp-script-library/.template.config/template.json
@@ -8,7 +8,8 @@
   "description": "Creates a TypeScript web resource library: .csproj (ProjectType=ScriptLibrary) + TS/tsconfig.json (outFile=single AMD .js, es6, @types/xrm) + TS/package.json (@types/xrm, typescript). Individual TS files in TS/scripts/ compile to one JS file. That output is picked up by pp-webresource build target. After generating, add it as a reference to the solution that uses it (e.g. if you generated 'solution.script' and want to use it in 'solution.ui', run 'dotnet add reference ../solution.script/solution.script.csproj' from the solution.ui directory).",
   "tags": {
     "language": "javascript",
-    "type": "project"
+    "type": "project",
+    "componentType": "WebResource"
   },
   "sourceName": "examplesourcename",
   "preferNameDirectory": true,

--- a/src/Dataverse/templates/pp-security-role-privilege/.template.config/template.json
+++ b/src/Dataverse/templates/pp-security-role-privilege/.template.config/template.json
@@ -10,7 +10,7 @@
   "tags": {
 		"type": "item",
 		"language": "XML",
-		"componentType": "Role"
+		"componentType": "SecurityRolePrivilege"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-security-role-privilege/.template.config/template.json
+++ b/src/Dataverse/templates/pp-security-role-privilege/.template.config/template.json
@@ -9,7 +9,8 @@
   "sourceName": "Role-Privilege",
   "tags": {
 		"type": "item",
-		"language": "XML"
+		"language": "XML",
+		"componentType": "Role"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-security-role/.template.config/template.json
+++ b/src/Dataverse/templates/pp-security-role/.template.config/template.json
@@ -9,7 +9,8 @@
   "sourceName": "Security-Role",
   "tags": {
 		"type": "item",
-		"language": "XML"
+		"language": "XML",
+		"componentType": "Role"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-security-role/.template.config/template.json
+++ b/src/Dataverse/templates/pp-security-role/.template.config/template.json
@@ -10,7 +10,7 @@
   "tags": {
 		"type": "item",
 		"language": "XML",
-		"componentType": "Role"
+		"componentType": "SecurityRole"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-sitemap-area/.template.config/template.json
+++ b/src/Dataverse/templates/pp-sitemap-area/.template.config/template.json
@@ -10,7 +10,7 @@
   "tags": {
 		"type": "item",
 		"language": "XML",
-		"componentType": "SiteMap"
+		"componentType": "SiteMapArea"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-sitemap-area/.template.config/template.json
+++ b/src/Dataverse/templates/pp-sitemap-area/.template.config/template.json
@@ -9,7 +9,8 @@
   "sourceName": "Sitemap-Area",
   "tags": {
 		"type": "item",
-		"language": "XML"
+		"language": "XML",
+		"componentType": "SiteMap"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-sitemap-group/.template.config/template.json
+++ b/src/Dataverse/templates/pp-sitemap-group/.template.config/template.json
@@ -9,7 +9,8 @@
   "sourceName": "Sitemap-Area-Group",
   "tags": {
 		"type": "item",
-		"language": "XML"
+		"language": "XML",
+		"componentType": "SiteMap"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-sitemap-group/.template.config/template.json
+++ b/src/Dataverse/templates/pp-sitemap-group/.template.config/template.json
@@ -10,7 +10,7 @@
   "tags": {
 		"type": "item",
 		"language": "XML",
-		"componentType": "SiteMap"
+		"componentType": "SiteMapGroup"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-sitemap-subarea/.template.config/template.json
+++ b/src/Dataverse/templates/pp-sitemap-subarea/.template.config/template.json
@@ -9,7 +9,8 @@
   "sourceName": "Sitemap-Area-Group-SubArea",
   "tags": {
 		"type": "item",
-		"language": "XML"
+		"language": "XML",
+		"componentType": "SiteMap"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-sitemap-subarea/.template.config/template.json
+++ b/src/Dataverse/templates/pp-sitemap-subarea/.template.config/template.json
@@ -10,7 +10,7 @@
   "tags": {
 		"type": "item",
 		"language": "XML",
-		"componentType": "SiteMap"
+		"componentType": "SiteMapSubArea"
 	},
   "preferNameDirectory": true,
   "symbols": {

--- a/src/Dataverse/templates/pp-solution/.template.config/template.json
+++ b/src/Dataverse/templates/pp-solution/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Creates a Dataverse solution project: .csproj (TALXIS.DevKit.Build.Sdk, ProjectType=Solution, PublisherName, PublisherPrefix, Version=1.0.0.0). Includes Solution.xml, Customizations.xml and Relationships.xml. A repo typically has multiple solution projects with separate concerns (data model, logic, security, UI).",
   "tags": {
     "language": "C#",
-    "type": "project"
+    "type": "project",
+    "componentType": "Solution"
   },
   "sourceName": "SolutionLogicalNameExample",
   "sources": [

--- a/src/Dataverse/templates/pp-webresource/.template.config/template.json
+++ b/src/Dataverse/templates/pp-webresource/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Registers a web resource in a Dataverse solution: JsBuildTarget.xml (MSBuild target: builds the script library project -> validates JS output -> copies to WebResources/ with publisher prefix) + {publisher}_{name}.data.xml (WebResourceId, Name, DisplayName, WebResourceType, Version). Works with pp-script-library: compiled JS gets deployed as {publisher}_{name}.js.",
     "tags": {
         "language": "XML",
-        "type": "item"
+        "type": "item",
+        "componentType": "WebResource"
     },
     "sourceName": "examplesourcename",
     "preferNameDirectory": true,

--- a/src/Dataverse/templates/pp-workflow-activity/.template.config/template.json
+++ b/src/Dataverse/templates/pp-workflow-activity/.template.config/template.json
@@ -8,7 +8,7 @@
   "tags": {
     "language": "C#",
     "type": "project",
-    "componentType": "Workflow"
+    "componentType": "WorkflowActivity"
   },
   "sourceName": "SolutionLogicalNameExample",
   "sources": [

--- a/src/Dataverse/templates/pp-workflow-activity/.template.config/template.json
+++ b/src/Dataverse/templates/pp-workflow-activity/.template.config/template.json
@@ -7,7 +7,8 @@
   "description": "Creates WorkflowActivityBase.cs: abstract CodeActivity with sealed Execute() that initializes IWorkflowContext, two IOrganizationService instances (user + system context), ITracingService, then calls virtual Execute() for subclass implementation. Use for custom Dynamics 365 workflow steps.",
   "tags": {
     "language": "C#",
-    "type": "project"
+    "type": "project",
+    "componentType": "Workflow"
   },
   "sourceName": "SolutionLogicalNameExample",
   "sources": [


### PR DESCRIPTION
## Summary

Add unique `componentType` tags to all 42 scaffolding templates, enabling 1:1 mapping between templates and the component type namespace used by `txc` CLI.

### What changed

Every `.template.config/template.json` under `src/Dataverse/templates/` gets a `componentType` entry in its `tags` object:

```json
"tags": {
    "language": "XML",
    "type": "item",
    "componentType": "Entity"
}
```

### Mapping

42 templates tagged with unique values. 6 templates excluded (test/package — not components).

Types that map to `ComponentDefinitionRegistry` entries: Entity, Attribute, Workflow, Role, WebResource, PluginAssembly, SdkMessageProcessingStep, CustomControl, AppModule, OptionSet, Solution, SavedQuery.

Sub-part types (unique to templates, no registry entry yet): EntityForm, EntityView, FormTab, FormSection, FormRow, FormCell, FormControl, FormSubgrid, FormEventHandler, FormParameter, FormDialogTabFooter, Flow, BusinessProcessFlow, BpfStage, BpfStageStep, WorkflowActivity, SecurityRole, SecurityRolePrivilege, ScriptLibrary, Plugin, PluginAssemblyStep, PcfControl, ControlParameter, AppModuleComponent, AppSecurityRole, AppCode, AppCodeData, SiteMapArea, SiteMapGroup, SiteMapSubArea, RibbonButton, RibbonButtonHide, RibbonCommandParameter, CustomAPI.

### Why

The `txc` CLI uses `componentType` to resolve user input to the right template. When a user types `txc ws component create FormTab`, the CLI matches it to `pp-form-tab` via the tag. When they type `txc component type explain Entity`, it finds `pp-entity` for the description.

Previously, multiple templates shared the same componentType (e.g. 11 templates all tagged `SystemForm`), causing ambiguous resolution. Now every template has a unique value.

### Companion PRs

- [tools-cli#101](https://github.com/TALXIS/tools-cli/pull/101): component type system + TemplateResolver
- [platform-metadata#56](https://github.com/TALXIS/platform-metadata/issues/56): tracking issue for sub-part types in registry