### PR TITLE
feat: pp-ribbon-button — Sequence, TemplateAlias, ModernImage params

### DIFF
--- a/src/Dataverse/templates/pp-ribbon-button/.template.config/template.json
+++ b/src/Dataverse/templates/pp-ribbon-button/.template.config/template.json
@@ -74,6 +74,28 @@
 			"fileRename": "__image-16x16__",
 			"description": "Path to the 16x16 pixel icon image for the ribbon button"
 		},
+		"ModernImage": {
+			"type": "parameter",
+			"datatype": "text",
+			"defaultValue": "modernimagedefault",
+			"replaces": "__modern-image__",
+			"fileRename": "__modern-image__",
+			"description": "Optional. Web resource path for a modern SVG icon (e.g. 'myicon.svg' or 'subfolder/myicon.svg'). Rendered as ModernImage=\"$webresource:<value>\". Omitted from XML when not specified."
+		},
+		"Sequence": {
+			"type": "parameter",
+			"datatype": "text",
+			"defaultValue": "10",
+			"replaces": "__sequence__",
+			"description": "Display order of the button within its location. Lower values appear first (PCT examples range from 1 to ~95). Default: 10."
+		},
+		"TemplateAlias": {
+			"type": "parameter",
+			"datatype": "text",
+			"defaultValue": "o1",
+			"replaces": "__template-alias__",
+			"description": "Layout slot alias inside the ribbon template (Common values: o1, o2, o3, isv). Default: o1."
+		},
 		"Location": {
 			"type": "parameter",
 			"datatype": "choice",

--- a/src/Dataverse/templates/pp-ribbon-button/.template.scripts/SetIcon.ps1
+++ b/src/Dataverse/templates/pp-ribbon-button/.template.scripts/SetIcon.ps1
@@ -2,12 +2,13 @@ $filePath = ".template.temp\custom-action.xml"
 
 $icon16Path = "__image-16x16__"
 $icon32Path = "__image-32x32__"
+$modernImagePath = "__modern-image__"
 
 function Replace-ButtonIcon {
     param (
-        [string]$FilePath,      
-        [string]$replaseString, 
-        [string]$iconPath       
+        [string]$FilePath,
+        [string]$replaseString,
+        [string]$iconPath
     )
 
     $content = Get-Content -Path $FilePath -Raw
@@ -27,6 +28,13 @@ if ($icon32Path -eq "icon32pathdefault") {
 } else {
     $path32 = 'Image32by32="$webresource:' + $icon32Path + '"'
     Replace-ButtonIcon -FilePath $filePath -replaseString "__icon-32x32-placeholder__" -iconPath $path32
+}
+
+if ($modernImagePath -eq "modernimagedefault") {
+    Replace-ButtonIcon -FilePath $filePath -replaseString "__modern-image-placeholder__" -iconPath ""
+} else {
+    $modern = 'ModernImage="$webresource:' + $modernImagePath + '"'
+    Replace-ButtonIcon -FilePath $filePath -replaseString "__modern-image-placeholder__" -iconPath $modern
 }
 
 

--- a/src/Dataverse/templates/pp-ribbon-button/.template.temp/custom-action.xml
+++ b/src/Dataverse/templates/pp-ribbon-button/.template.temp/custom-action.xml
@@ -2,14 +2,14 @@
   <CustomAction
     Id="__publisher-prefix__.__entity-logical-name__.Button.__button-logical-name__.CustomAction"
     Location="Mscrm.__location-path__.__entity-logical-name__.__tab-path__"
-    Sequence="10">
+    Sequence="__sequence__">
     <CommandUIDefinition>
       <Button
         Alt="$LocLabels:__publisher-prefix__.__entity-logical-name__.Button.__button-logical-name__.Alt"
         Command="__publisher-prefix__.__entity-logical-name__.Command.__button-logical-name__"
-        Id="__publisher-prefix__.__entity-logical-name__.Button.__button-logical-name__" __icon-16x16-placeholder__ __icon-32x32-placeholder__
+        Id="__publisher-prefix__.__entity-logical-name__.Button.__button-logical-name__" __icon-16x16-placeholder__ __icon-32x32-placeholder__ __modern-image-placeholder__
         LabelText="$LocLabels:__publisher-prefix__.__entity-logical-name__.Button.__button-logical-name__.LabelText"
-        Sequence="10" TemplateAlias="o1"
+        Sequence="__sequence__" TemplateAlias="__template-alias__"
         ToolTipTitle="$LocLabels:__publisher-prefix__.__entity-logical-name__.Button.__button-logical-name__.ToolTipTitle"
         ToolTipDescription="$LocLabels:__publisher-prefix__.__entity-logical-name__.Button.__button-logical-name__.ToolTipDescription" />
     </CommandUIDefinition>


### PR DESCRIPTION
- Sequence and TemplateAlias promoted from hardcoded "10"/"o1" to optional params with same defaults (closes #88).
- New optional --ModernImage param emits ModernImage="$webresource:<value>" on <Button>, omitted entirely when not passed (closes #85).
- Backward-compatible: omitting all three new flags yields identical XML to before.