### PR TITLE
feat: add pp-page-generative template + upgrade pp-sitemap-subarea

### DIFF
--- a/src/Dataverse/templates/pp-page-generative/.gitignore
+++ b/src/Dataverse/templates/pp-page-generative/.gitignore
@@ -1,0 +1,3 @@
+page.js
+obj/
+bin/

--- a/src/Dataverse/templates/pp-page-generative/.gitignore
+++ b/src/Dataverse/templates/pp-page-generative/.gitignore
@@ -1,3 +1,2 @@
 page.js
-obj/
-bin/
+node_modules/

--- a/src/Dataverse/templates/pp-page-generative/.template.config/template.json
+++ b/src/Dataverse/templates/pp-page-generative/.template.config/template.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "NETWORG",
+  "identity": "TALXIS.DevKit.Templates.Dataverse.GenPage",
+  "name": "Power Platform: Generative Page",
+  "shortName": "pp-page-generative",
+  "description": "Scaffolds a generative page project: page.tsx (React 17 + Fluent UI V9) that renders natively inside model-driven apps. Build with 'dotnet build' — the SDK transpiles TSX to JS via tsc and packs it into the solution as a UX Agent Project. No PAC CLI dependency for build. CHAIN: Step 1 — create this project. Step 2 — add it as a project reference from the solution project. Step 3 — add a sitemap subarea with PageType=genpage pointing to this page's GenPageId. Step 4 — 'dotnet build' the solution.",
+  "classifications": ["Dataverse", "Power Platform", "Generative Page"],
+  "sourceName": "__project-name__",
+  "preferNameDirectory": true,
+  "tags": {
+    "type": "project",
+    "language": "TypeScript",
+    "componentType": "GenPage"
+  },
+  "symbols": {
+    "Name": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "__genpage-name__",
+      "fileRename": "__genpage-name__",
+      "isRequired": true,
+      "description": "Logical name of the generative page (used in solution schema name, e.g., 'accountdashboard')"
+    },
+    "DisplayName": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "__genpage-display-name__",
+      "isRequired": true,
+      "description": "Display name shown in the model-driven app sitemap navigation"
+    },
+    "DataSources": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "__genpage-data-sources__",
+      "defaultValue": "",
+      "description": "Comma-separated Dataverse table logical names used by this page (e.g., 'account,contact')"
+    },
+    "PageId": {
+      "type": "generated",
+      "generator": "guid",
+      "replaces": "__genpage-id__",
+      "parameters": {
+        "defaultFormat": "d"
+      }
+    }
+  },
+  "primaryOutputs": [
+    { "path": "__project-name__.csproj" }
+  ],
+  "postActions": [
+    {
+      "description": "Add generated project to .sln file",
+      "actionId": "D396686C-DE0E-4DE6-906D-291CD29FC5DE",
+      "args": { "inRoot": true },
+      "continueOnError": false,
+      "primaryOutputIndexes": "0"
+    }
+  ]
+}

--- a/src/Dataverse/templates/pp-page-generative/.template.config/template.json
+++ b/src/Dataverse/templates/pp-page-generative/.template.config/template.json
@@ -28,13 +28,6 @@
       "isRequired": true,
       "description": "Display name shown in the model-driven app sitemap navigation"
     },
-    "DataSources": {
-      "type": "parameter",
-      "datatype": "text",
-      "replaces": "__genpage-data-sources__",
-      "defaultValue": "",
-      "description": "Comma-separated Dataverse table logical names used by this page (e.g., 'account,contact')"
-    },
     "PageId": {
       "type": "generated",
       "generator": "guid",

--- a/src/Dataverse/templates/pp-page-generative/.template.config/template.json
+++ b/src/Dataverse/templates/pp-page-generative/.template.config/template.json
@@ -6,7 +6,7 @@
   "shortName": "pp-page-generative",
   "description": "Creates a generative page project: page.tsx (React 17 + Fluent UI V9, export default GeneratedComponent) + .csproj (ProjectType=GenPage). CHAIN: Step 1 — create this project. Step 2 — add as project reference from solution. Step 3 — add sitemap subarea with PageType=genpage. Step 4 — dotnet build.",
   "classifications": ["Dataverse", "Power Platform"],
-  "sourceName": "GenPageExample",
+  "sourceName": "__project-name__",
   "preferNameDirectory": true,
   "tags": {
     "type": "project",
@@ -14,30 +14,38 @@
     "componentType": "GenPage"
   },
   "symbols": {
+    "Name": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "__genpage-name__",
+      "isRequired": true,
+      "description": "Logical name of the generative page (used in solution schema name, e.g., 'accountdashboard')"
+    },
     "DisplayName": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "genpageexampleDisplayName",
+      "replaces": "__genpage-display-name__",
+      "isRequired": true,
       "description": "Display name shown in the model-driven app sitemap navigation"
     },
     "DataSources": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "genpageexampleDataSources",
+      "replaces": "__genpage-data-sources__",
       "defaultValue": "",
       "description": "Comma-separated Dataverse table logical names used by this page (e.g., 'account,contact')"
     },
     "PageId": {
       "type": "generated",
       "generator": "guid",
-      "replaces": "genpageexampleId",
+      "replaces": "__genpage-id__",
       "parameters": {
         "defaultFormat": "d"
       }
     }
   },
   "primaryOutputs": [
-    { "path": "GenPageExample.csproj" }
+    { "path": "__project-name__.csproj" }
   ],
   "postActions": [
     {

--- a/src/Dataverse/templates/pp-page-generative/.template.config/template.json
+++ b/src/Dataverse/templates/pp-page-generative/.template.config/template.json
@@ -4,9 +4,9 @@
   "identity": "TALXIS.DevKit.Templates.Dataverse.GenPage",
   "name": "Power Platform: Generative Page",
   "shortName": "pp-page-generative",
-  "description": "Scaffolds a generative page project: page.tsx (React 17 + Fluent UI V9) that renders natively inside model-driven apps. Build with 'dotnet build' — the SDK transpiles TSX to JS via tsc and packs it into the solution as a UX Agent Project. No PAC CLI dependency for build. CHAIN: Step 1 — create this project. Step 2 — add it as a project reference from the solution project. Step 3 — add a sitemap subarea with PageType=genpage pointing to this page's GenPageId. Step 4 — 'dotnet build' the solution.",
-  "classifications": ["Dataverse", "Power Platform", "Generative Page"],
-  "sourceName": "__project-name__",
+  "description": "Creates a generative page project: page.tsx (React 17 + Fluent UI V9, export default GeneratedComponent) + .csproj (ProjectType=GenPage). CHAIN: Step 1 — create this project. Step 2 — add as project reference from solution. Step 3 — add sitemap subarea with PageType=genpage. Step 4 — dotnet build.",
+  "classifications": ["Dataverse", "Power Platform"],
+  "sourceName": "GenPageExample",
   "preferNameDirectory": true,
   "tags": {
     "type": "project",
@@ -14,39 +14,30 @@
     "componentType": "GenPage"
   },
   "symbols": {
-    "Name": {
-      "type": "parameter",
-      "datatype": "text",
-      "replaces": "__genpage-name__",
-      "fileRename": "__genpage-name__",
-      "isRequired": true,
-      "description": "Logical name of the generative page (used in solution schema name, e.g., 'accountdashboard')"
-    },
     "DisplayName": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "__genpage-display-name__",
-      "isRequired": true,
+      "replaces": "genpageexampleDisplayName",
       "description": "Display name shown in the model-driven app sitemap navigation"
     },
     "DataSources": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "__genpage-data-sources__",
+      "replaces": "genpageexampleDataSources",
       "defaultValue": "",
       "description": "Comma-separated Dataverse table logical names used by this page (e.g., 'account,contact')"
     },
     "PageId": {
       "type": "generated",
       "generator": "guid",
-      "replaces": "__genpage-id__",
+      "replaces": "genpageexampleId",
       "parameters": {
         "defaultFormat": "d"
       }
     }
   },
   "primaryOutputs": [
-    { "path": "__project-name__.csproj" }
+    { "path": "GenPageExample.csproj" }
   ],
   "postActions": [
     {

--- a/src/Dataverse/templates/pp-page-generative/GenPageExample.csproj
+++ b/src/Dataverse/templates/pp-page-generative/GenPageExample.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <ProjectType>GenPage</ProjectType>
-    <GenPageName>__genpage-name__</GenPageName>
-    <GenPageId>__genpage-id__</GenPageId>
-    <GenPageDataSources>__genpage-data-sources__</GenPageDataSources>
+    <GenPageName>genpageexample</GenPageName>
+    <GenPageId>genpageexampleId</GenPageId>
+    <GenPageDataSources>genpageexampleDataSources</GenPageDataSources>
   </PropertyGroup>
 </Project>

--- a/src/Dataverse/templates/pp-page-generative/RuntimeTypes.js
+++ b/src/Dataverse/templates/pp-page-generative/RuntimeTypes.js
@@ -1,0 +1,3 @@
+// RuntimeTypes JS enums — regenerated from Dataverse metadata.
+// This file is prepended to the compiled page output during build.
+// Leave empty if your page doesn't use typed enum values.

--- a/src/Dataverse/templates/pp-page-generative/RuntimeTypes.ts
+++ b/src/Dataverse/templates/pp-page-generative/RuntimeTypes.ts
@@ -1,0 +1,43 @@
+// Stub RuntimeTypes — regenerate with: pac model genpage generate-types --data-sources "table1,table2"
+// These types provide IDE IntelliSense for the generative page component.
+
+export type TableRow<T> = T & { readonly [key: string]: any };
+export type ReadableTableRow<T> = T;
+
+export interface DataTable<T = any> {
+  rows: T[];
+  hasMoreRows: boolean;
+  loadMoreRows?: () => Promise<DataTable<T>>;
+}
+
+export interface QueryTableOptions {
+  select?: string[];
+  filter?: string;
+  orderBy?: string;
+  pageSize?: number;
+}
+
+export interface RetrieveRowOptions {
+  id: string;
+  select?: string[];
+}
+
+export interface UxAgentDataApi {
+  createRow(tableName: string, row: object): Promise<string>;
+  updateRow(tableName: string, rowId: string, row: object): Promise<void>;
+  deleteRow(tableName: string, rowId: string): Promise<void>;
+  retrieveRow(tableName: string, options: RetrieveRowOptions): Promise<any>;
+  queryTable<T = any>(tableName: string, query: QueryTableOptions): Promise<DataTable<T>>;
+  getChoices(enumName: string): Promise<{ label: string; value: number }[]>;
+}
+
+export interface PageInput {
+  entityName?: string;
+  recordId?: string;
+  data?: Record<string, unknown>;
+}
+
+export interface GeneratedComponentProps {
+  dataApi: UxAgentDataApi;
+  pageInput: PageInput;
+}

--- a/src/Dataverse/templates/pp-page-generative/__project-name__.csproj
+++ b/src/Dataverse/templates/pp-page-generative/__project-name__.csproj
@@ -4,6 +4,5 @@
     <ProjectType>GenPage</ProjectType>
     <GenPageName>__genpage-name__</GenPageName>
     <GenPageId>__genpage-id__</GenPageId>
-    <GenPageDataSources>__genpage-data-sources__</GenPageDataSources>
   </PropertyGroup>
 </Project>

--- a/src/Dataverse/templates/pp-page-generative/__project-name__.csproj
+++ b/src/Dataverse/templates/pp-page-generative/__project-name__.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <ProjectType>GenPage</ProjectType>
-    <GenPageName>genpageexample</GenPageName>
-    <GenPageId>genpageexampleId</GenPageId>
-    <GenPageDataSources>genpageexampleDataSources</GenPageDataSources>
+    <GenPageName>__genpage-name__</GenPageName>
+    <GenPageId>__genpage-id__</GenPageId>
+    <GenPageDataSources>__genpage-data-sources__</GenPageDataSources>
   </PropertyGroup>
 </Project>

--- a/src/Dataverse/templates/pp-page-generative/__project-name__.csproj
+++ b/src/Dataverse/templates/pp-page-generative/__project-name__.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="TALXIS.DevKit.Build.Sdk/1.4.0">
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+    <ProjectType>GenPage</ProjectType>
+    <GenPageName>__genpage-name__</GenPageName>
+    <GenPageId>__genpage-id__</GenPageId>
+    <GenPageDataSources>__genpage-data-sources__</GenPageDataSources>
+  </PropertyGroup>
+</Project>

--- a/src/Dataverse/templates/pp-page-generative/genpage.config.json
+++ b/src/Dataverse/templates/pp-page-generative/genpage.config.json
@@ -1,0 +1,4 @@
+{
+  "dataSources": [],
+  "model": ""
+}

--- a/src/Dataverse/templates/pp-page-generative/page.tsx
+++ b/src/Dataverse/templates/pp-page-generative/page.tsx
@@ -20,7 +20,8 @@ const useStyles = makeStyles({
 });
 
 const GeneratedComponent = (props: GeneratedComponentProps) => {
-  const { dataApi, pageInput } = props;
+  // Access Dataverse data via props.dataApi
+  // Access navigation context via props.pageInput
   const styles = useStyles();
   const [loading, setLoading] = useState(true);
 

--- a/src/Dataverse/templates/pp-page-generative/page.tsx
+++ b/src/Dataverse/templates/pp-page-generative/page.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import {
+  makeStyles,
+  Title1,
+  Card,
+  CardHeader,
+  Text,
+  Spinner,
+  tokens
+} from '@fluentui/react-components';
+import type { GeneratedComponentProps } from './RuntimeTypes';
+
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalL,
+    padding: tokens.spacingHorizontalXL,
+  },
+});
+
+const GeneratedComponent = (props: GeneratedComponentProps) => {
+  const { dataApi, pageInput } = props;
+  const styles = useStyles();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(false);
+  }, []);
+
+  if (loading) {
+    return <Spinner label="Loading..." />;
+  }
+
+  return (
+    <div className={styles.container}>
+      <Title1>__genpage-display-name__</Title1>
+      <Card>
+        <CardHeader header={<Text weight="semibold">Getting Started</Text>} />
+        <Text>Edit page.tsx to build your generative page. Use props.dataApi for Dataverse CRUD operations.</Text>
+      </Card>
+    </div>
+  );
+};
+
+export default GeneratedComponent;

--- a/src/Dataverse/templates/pp-page-generative/page.tsx
+++ b/src/Dataverse/templates/pp-page-generative/page.tsx
@@ -34,7 +34,7 @@ const GeneratedComponent = (props: GeneratedComponentProps) => {
 
   return (
     <div className={styles.container}>
-      <Title1>__genpage-display-name__</Title1>
+      <Title1>genpageexampleDisplayName</Title1>
       <Card>
         <CardHeader header={<Text weight="semibold">Getting Started</Text>} />
         <Text>Edit page.tsx to build your generative page. Use props.dataApi for Dataverse CRUD operations.</Text>

--- a/src/Dataverse/templates/pp-page-generative/page.tsx
+++ b/src/Dataverse/templates/pp-page-generative/page.tsx
@@ -34,7 +34,7 @@ const GeneratedComponent = (props: GeneratedComponentProps) => {
 
   return (
     <div className={styles.container}>
-      <Title1>genpageexampleDisplayName</Title1>
+      <Title1>__genpage-display-name__</Title1>
       <Card>
         <CardHeader header={<Text weight="semibold">Getting Started</Text>} />
         <Text>Edit page.tsx to build your generative page. Use props.dataApi for Dataverse CRUD operations.</Text>

--- a/src/Dataverse/templates/pp-sitemap-subarea/.template.config/template.json
+++ b/src/Dataverse/templates/pp-sitemap-subarea/.template.config/template.json
@@ -136,24 +136,11 @@
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
       "args": {
         "executable": "pwsh",
-        "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/GenerateIdForAppModuleSiteMap.ps1\" "
-      },
-      "manualInstructions": [
-        {
-          "text": "Adding Model Driven App to solution xml"
-        }
-      ],
-      "description": "Generate ID for app module site map"
-    },
-    {
-      "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
-      "args": {
-        "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/AddSubAreaToGroup.ps1\""
       },
       "manualInstructions": [
         {
-          "text": "Adding area to the sitemapp "
+          "text": "Adding subarea to the sitemap group"
         }
       ],
       "description": "Add sub area to group"

--- a/src/Dataverse/templates/pp-sitemap-subarea/.template.config/template.json
+++ b/src/Dataverse/templates/pp-sitemap-subarea/.template.config/template.json
@@ -41,8 +41,7 @@
       "type": "parameter",
       "datatype": "text",
       "description": "Logical name of the entity including publisher prefix (e.g., udpp_warehouseitem). Required for entity, entitylist, and control page types.",
-      "isRequired": false,
-      "defaultValue": "",
+      "isRequired": true,
       "replaces": "entityexamplename"
     },
     "ViewId": {

--- a/src/Dataverse/templates/pp-sitemap-subarea/.template.config/template.json
+++ b/src/Dataverse/templates/pp-sitemap-subarea/.template.config/template.json
@@ -4,7 +4,7 @@
   "identity": "TALXIS.DevKit.Templates.Dataverse.Sitemap.Area.Group.SubArea",
   "name": "Power Platform: Site Map Area Group SubArea",
   "shortName": "pp-sitemap-subarea",
-  "description": "Adds <SubArea> to a sitemap group: Id, Entity reference, Client=All/Outlook/Web, AvailableOffline=true, PassParams=false, Sku=All. Leaf navigation item linking to an entity list.",
+  "description": "Adds <SubArea> to a sitemap group. Supports entity, entitylist, dashboard, control, custom page, web resource, and generative page types.",
   "classifications": ["Dataverse", "Power Platform"],
   "sourceName": "Sitemap-Area-Group-SubArea",
   "tags": {
@@ -14,12 +14,78 @@
 	},
   "preferNameDirectory": true,
   "symbols": {
+    "PageType": {
+      "type": "parameter",
+      "datatype": "choice",
+      "choices": [
+        { "choice": "entity", "description": "Entity list (default view)" },
+        { "choice": "entitylist", "description": "Entity list with specific view" },
+        { "choice": "dashboard", "description": "Dashboard" },
+        { "choice": "control", "description": "PCF control page" },
+        { "choice": "custom", "description": "Custom page" },
+        { "choice": "webresource", "description": "Web resource page" },
+        { "choice": "genpage", "description": "Generative page (React)" }
+      ],
+      "defaultValue": "entity",
+      "replaces": "__page-type__",
+      "description": "Type of page this subarea links to"
+    },
+    "Title": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "__subarea-title__",
+      "isRequired": true,
+      "description": "Display title for the navigation item"
+    },
     "EntityLogicalName": {
       "type": "parameter",
       "datatype": "text",
-      "description": "Logical name of the entity including publisher prefix (e.g., udpp_warehouseitem)",
-      "isRequired": true,
+      "description": "Logical name of the entity including publisher prefix (e.g., udpp_warehouseitem). Required for entity, entitylist, and control page types.",
+      "isRequired": false,
+      "defaultValue": "",
       "replaces": "entityexamplename"
+    },
+    "ViewId": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "__view-id__",
+      "defaultValue": "",
+      "description": "Saved query GUID (required when PageType=entitylist)"
+    },
+    "DashboardId": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "__dashboard-id__",
+      "defaultValue": "",
+      "description": "Dashboard GUID (required when PageType=dashboard)"
+    },
+    "ControlName": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "__control-name__",
+      "defaultValue": "",
+      "description": "PCF control name (required when PageType=control)"
+    },
+    "GenPageId": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "__genpage-id__",
+      "defaultValue": "",
+      "description": "Generative page GUID from the GenPage project (required when PageType=genpage)"
+    },
+    "CustomPageName": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "__custom-page-name__",
+      "defaultValue": "",
+      "description": "Custom page logical name (required when PageType=custom)"
+    },
+    "WebResourceName": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "__webresource-name__",
+      "defaultValue": "",
+      "description": "Web resource name (required when PageType=webresource)"
     },
     "SolutionRootPath": {
 			"type": "parameter",

--- a/src/Dataverse/templates/pp-sitemap-subarea/.template.scripts/AddSubAreaToGroup.ps1
+++ b/src/Dataverse/templates/pp-sitemap-subarea/.template.scripts/AddSubAreaToGroup.ps1
@@ -26,16 +26,43 @@ if (-not $groupNode) {
     exit 1
 }
 
-# Parameters injected by dotnet new template engine
-$PageType        = '__page-type__'
-$Title           = '__subarea-title__'
-$EntityName      = 'entityexamplename'
-$ViewId          = '__view-id__'
-$DashboardId     = '__dashboard-id__'
-$ControlName     = '__control-name__'
-$GenPageId       = '__genpage-id__'
-$CustomPageName  = '__custom-page-name__'
-$WebResourceName = '__webresource-name__'
+# Parameters injected by dotnet new template engine.
+# Here-strings prevent apostrophes / special chars from breaking PS parsing.
+$PageType = @'
+__page-type__
+'@
+
+$Title = @'
+__subarea-title__
+'@
+
+$EntityName = @'
+entityexamplename
+'@
+
+$ViewId = @'
+__view-id__
+'@
+
+$DashboardId = @'
+__dashboard-id__
+'@
+
+$ControlName = @'
+__control-name__
+'@
+
+$GenPageId = @'
+__genpage-id__
+'@
+
+$CustomPageName = @'
+__custom-page-name__
+'@
+
+$WebResourceName = @'
+__webresource-name__
+'@
 
 $subareaId = "subarea_" + ([guid]::NewGuid().ToString() -split '-')[0]
 $commonAttrs = "Client=`"All,Outlook,OutlookLaptopClient,OutlookWorkstationClient,Web`" AvailableOffline=`"true`" PassParams=`"false`" Sku=`"All,OnPremise,Live,SPLA`""
@@ -44,28 +71,60 @@ $titlesXml = "<Titles><Title LCID=`"1033`" Title=`"$escapedTitle`" /></Titles>"
 
 switch ($PageType) {
     'entity' {
+        if ([string]::IsNullOrWhiteSpace($EntityName)) {
+            Write-Error "EntityLogicalName is required when PageType is 'entity'"
+            exit 1
+        }
         $subareaXmlString = "<SubArea Id=`"$subareaId`" Icon=`"/_imgs/imagestrips/transparent_spacer.gif`" Entity=`"$EntityName`" $commonAttrs>$titlesXml</SubArea>"
     }
     'entitylist' {
+        if ([string]::IsNullOrWhiteSpace($EntityName)) {
+            Write-Error "EntityLogicalName is required when PageType is 'entitylist'"
+            exit 1
+        }
+        if ([string]::IsNullOrWhiteSpace($ViewId)) {
+            Write-Error "ViewId is required when PageType is 'entitylist'"
+            exit 1
+        }
         $url = "/main.aspx?pagetype=entitylist&amp;etn=$EntityName&amp;viewid=$ViewId"
         $subareaXmlString = "<SubArea Id=`"$subareaId`" Icon=`"/_imgs/imagestrips/transparent_spacer.gif`" Url=`"$url`" $commonAttrs>$titlesXml</SubArea>"
     }
     'dashboard' {
+        if ([string]::IsNullOrWhiteSpace($DashboardId)) {
+            Write-Error "DashboardId is required when PageType is 'dashboard'"
+            exit 1
+        }
         $subareaXmlString = "<SubArea Id=`"$subareaId`" Icon=`"/_imgs/imagestrips/transparent_spacer.gif`" Url=`"/workplace/home_dashboards.aspx`" DefaultDashboard=`"$DashboardId`" $commonAttrs>$titlesXml</SubArea>"
     }
     'control' {
+        if ([string]::IsNullOrWhiteSpace($ControlName)) {
+            Write-Error "ControlName is required when PageType is 'control'"
+            exit 1
+        }
         $url = "/main.aspx?pagetype=control&amp;controlName=$ControlName"
         $subareaXmlString = "<SubArea Id=`"$subareaId`" Icon=`"/_imgs/imagestrips/transparent_spacer.gif`" Url=`"$url`" Entity=`"$EntityName`" $commonAttrs>$titlesXml</SubArea>"
     }
     'custom' {
+        if ([string]::IsNullOrWhiteSpace($CustomPageName)) {
+            Write-Error "CustomPageName is required when PageType is 'custom'"
+            exit 1
+        }
         $url = "/main.aspx?pagetype=custom&amp;name=$CustomPageName"
         $subareaXmlString = "<SubArea Id=`"$subareaId`" Icon=`"/_imgs/imagestrips/transparent_spacer.gif`" Url=`"$url`" $commonAttrs>$titlesXml</SubArea>"
     }
     'webresource' {
+        if ([string]::IsNullOrWhiteSpace($WebResourceName)) {
+            Write-Error "WebResourceName is required when PageType is 'webresource'"
+            exit 1
+        }
         $url = "/main.aspx?pagetype=webresource&amp;webresourceName=$WebResourceName"
         $subareaXmlString = "<SubArea Id=`"$subareaId`" Icon=`"/_imgs/imagestrips/transparent_spacer.gif`" Url=`"$url`" $commonAttrs>$titlesXml</SubArea>"
     }
     'genpage' {
+        if ([string]::IsNullOrWhiteSpace($GenPageId)) {
+            Write-Error "GenPageId is required when PageType is 'genpage'"
+            exit 1
+        }
         $subareaXmlString = "<SubArea Id=`"$subareaId`" GenPageId=`"$GenPageId`" VectorIcon=`"/_imgs/TableIconsFluentV9/document_one_page_sparkle.svg`" $commonAttrs>$titlesXml</SubArea>"
     }
     default {

--- a/src/Dataverse/templates/pp-sitemap-subarea/.template.scripts/AddSubAreaToGroup.ps1
+++ b/src/Dataverse/templates/pp-sitemap-subarea/.template.scripts/AddSubAreaToGroup.ps1
@@ -17,10 +17,7 @@ if (-not $entityXmlPath) {
     exit 1
 }
 
-$subareaPath = (Resolve-Path '.template.temp/subarea.xml').Path
-
 [xml]$entityXml = Get-Content -Path $entityXmlPath -Raw
-[xml]$subareaXml = Get-Content -Path $subareaPath -Raw
 
 $groupNode = $entityXml.SelectSingleNode("//SiteMap/Area[@ResourceId='SitemapDesigner.areatitleexample']/Group[@ResourceId='SitemapDesigner.grouptitleexample']")
 
@@ -29,6 +26,55 @@ if (-not $groupNode) {
     exit 1
 }
 
+# Parameters injected by dotnet new template engine
+$PageType        = '__page-type__'
+$Title           = '__subarea-title__'
+$EntityName      = 'entityexamplename'
+$ViewId          = '__view-id__'
+$DashboardId     = '__dashboard-id__'
+$ControlName     = '__control-name__'
+$GenPageId       = '__genpage-id__'
+$CustomPageName  = '__custom-page-name__'
+$WebResourceName = '__webresource-name__'
+
+$subareaId = "subarea_" + ([guid]::NewGuid().ToString() -split '-')[0]
+$commonAttrs = "Client=`"All,Outlook,OutlookLaptopClient,OutlookWorkstationClient,Web`" AvailableOffline=`"true`" PassParams=`"false`" Sku=`"All,OnPremise,Live,SPLA`""
+$escapedTitle = [System.Security.SecurityElement]::Escape($Title)
+$titlesXml = "<Titles><Title LCID=`"1033`" Title=`"$escapedTitle`" /></Titles>"
+
+switch ($PageType) {
+    'entity' {
+        $subareaXmlString = "<SubArea Id=`"$subareaId`" Icon=`"/_imgs/imagestrips/transparent_spacer.gif`" Entity=`"$EntityName`" $commonAttrs>$titlesXml</SubArea>"
+    }
+    'entitylist' {
+        $url = "/main.aspx?pagetype=entitylist&amp;etn=$EntityName&amp;viewid=$ViewId"
+        $subareaXmlString = "<SubArea Id=`"$subareaId`" Icon=`"/_imgs/imagestrips/transparent_spacer.gif`" Url=`"$url`" $commonAttrs>$titlesXml</SubArea>"
+    }
+    'dashboard' {
+        $subareaXmlString = "<SubArea Id=`"$subareaId`" Icon=`"/_imgs/imagestrips/transparent_spacer.gif`" Url=`"/workplace/home_dashboards.aspx`" DefaultDashboard=`"$DashboardId`" $commonAttrs>$titlesXml</SubArea>"
+    }
+    'control' {
+        $url = "/main.aspx?pagetype=control&amp;controlName=$ControlName"
+        $subareaXmlString = "<SubArea Id=`"$subareaId`" Icon=`"/_imgs/imagestrips/transparent_spacer.gif`" Url=`"$url`" Entity=`"$EntityName`" $commonAttrs>$titlesXml</SubArea>"
+    }
+    'custom' {
+        $url = "/main.aspx?pagetype=custom&amp;name=$CustomPageName"
+        $subareaXmlString = "<SubArea Id=`"$subareaId`" Icon=`"/_imgs/imagestrips/transparent_spacer.gif`" Url=`"$url`" $commonAttrs>$titlesXml</SubArea>"
+    }
+    'webresource' {
+        $url = "/main.aspx?pagetype=webresource&amp;webresourceName=$WebResourceName"
+        $subareaXmlString = "<SubArea Id=`"$subareaId`" Icon=`"/_imgs/imagestrips/transparent_spacer.gif`" Url=`"$url`" $commonAttrs>$titlesXml</SubArea>"
+    }
+    'genpage' {
+        $subareaXmlString = "<SubArea Id=`"$subareaId`" GenPageId=`"$GenPageId`" VectorIcon=`"/_imgs/TableIconsFluentV9/document_one_page_sparkle.svg`" $commonAttrs>$titlesXml</SubArea>"
+    }
+    default {
+        Write-Error "Unknown PageType: $PageType"
+        exit 1
+    }
+}
+
+[xml]$subareaXml = $subareaXmlString
 $importedSubarea = $entityXml.ImportNode($subareaXml.DocumentElement, $true)
 $groupNode.AppendChild($importedSubarea) | Out-Null
 

--- a/src/Dataverse/templates/pp-sitemap-subarea/.template.scripts/Cleanup.ps1
+++ b/src/Dataverse/templates/pp-sitemap-subarea/.template.scripts/Cleanup.ps1
@@ -1,2 +1,1 @@
-Remove-Item .template.temp -Recurse -Force
 Remove-Item .template.scripts -Recurse -Force

--- a/src/Dataverse/templates/pp-sitemap-subarea/.template.scripts/GenerateIdForAppModuleSiteMap.ps1
+++ b/src/Dataverse/templates/pp-sitemap-subarea/.template.scripts/GenerateIdForAppModuleSiteMap.ps1
@@ -1,2 +1,0 @@
-# SubArea ID is now generated directly in AddSubAreaToGroup.ps1.
-# This script is kept as a no-op for backwards compatibility with the post-action chain.

--- a/src/Dataverse/templates/pp-sitemap-subarea/.template.scripts/GenerateIdForAppModuleSiteMap.ps1
+++ b/src/Dataverse/templates/pp-sitemap-subarea/.template.scripts/GenerateIdForAppModuleSiteMap.ps1
@@ -1,10 +1,2 @@
-$subareaPath  = (Resolve-Path '.template.temp/subarea.xml').Path
-
-[XML]$File = Get-Content -Path $subareaPath -Raw
-
-$XmlText = $File.OuterXml
-$modifiedXmlText = $XmlText -replace [Regex]::Escape("subareaidexample"), ([guid]::NewGuid().ToString() -split '-')[0]
-
-[XML]$File = $ModifiedXmlText
-
-$File.Save($subareaPath)
+# SubArea ID is now generated directly in AddSubAreaToGroup.ps1.
+# This script is kept as a no-op for backwards compatibility with the post-action chain.

--- a/src/Dataverse/templates/pp-sitemap-subarea/.template.temp/subarea.xml
+++ b/src/Dataverse/templates/pp-sitemap-subarea/.template.temp/subarea.xml
@@ -1,1 +1,0 @@
-<!-- SubArea XML is now generated dynamically by AddSubAreaToGroup.ps1 based on PageType. This file is kept as a placeholder. -->

--- a/src/Dataverse/templates/pp-sitemap-subarea/.template.temp/subarea.xml
+++ b/src/Dataverse/templates/pp-sitemap-subarea/.template.temp/subarea.xml
@@ -1,1 +1,1 @@
-<SubArea Id="subarea_subareaidexample" Icon="/_imgs/imagestrips/transparent_spacer.gif" Entity="entityexamplename" Client="All,Outlook,OutlookLaptopClient,OutlookWorkstationClient,Web" AvailableOffline="true" PassParams="false" Sku="All,OnPremise,Live,SPLA" />
+<!-- SubArea XML is now generated dynamically by AddSubAreaToGroup.ps1 based on PageType. This file is kept as a placeholder. -->


### PR DESCRIPTION
## Summary

### New template: `pp-page-generative`
Scaffolds a generative page project with `__dunder__` symbol naming:
- `__project-name__.csproj`: `ProjectType=GenPage`, `GenPageName`, `GenPageId` (auto-generated GUID)
- `page.tsx`: React 17 + Fluent UI V9 starter component (no unused destructuring)
- `RuntimeTypes.ts` / `.js`: stub type definitions for IDE IntelliSense
- `genpage.config.json`: data sources config (source file, not csproj property)
- `.gitignore`: `page.js` + `node_modules/` (matches pp-script-library style)

Usage: `dotnet new pp-page-generative -n MyPage --Name mypage --DisplayName "My Page"`

### Upgraded template: `pp-sitemap-subarea`
Added `PageType` choice parameter supporting all 7 UCI page types:

| PageType | Key attributes |
|---|---|
| `entity` (default) | `Entity="..."` |
| `entitylist` | `Url=".../pagetype=entitylist&etn=...&viewid=..."` |
| `dashboard` | `DefaultDashboard="..."` |
| `control` | `Url=".../pagetype=control&controlName=..."` |
| `custom` | `Url=".../pagetype=custom&name=..."` |
| `webresource` | `Url=".../pagetype=webresource&webresourceName=..."` |
| `genpage` | `GenPageId="..." VectorIcon="...sparkle.svg"` |

Additional improvements:
- `<Titles>` support on all SubArea types
- Per-PageType parameter validation (fail fast on missing required values)
- PowerShell here-strings for safe quoting (handles apostrophes in Title)
- XML escaping for Title values
- `EntityLogicalName` required (matches original behavior)
- Removed empty `subarea.xml` and no-op `GenerateIdForAppModuleSiteMap.ps1`