### PR TITLE
fix: CWD issues in template post-actions on .NET 10

### DIFF
--- a/src/Dataverse/templates/pp-app-security-role/.template.scripts/GenerateRolePrivileges.cs
+++ b/src/Dataverse/templates/pp-app-security-role/.template.scripts/GenerateRolePrivileges.cs
@@ -18,9 +18,7 @@ for (int i = 0; i < guids.Count; i++)
     guids[i] = guids[i].Trim();
 }
 
-var filePath = Path.Combine(".", ".template.scripts", "appaccess.xml");
-
-Directory.CreateDirectory(Path.GetDirectoryName(filePath));
+var filePath = Path.Combine(".", "appaccess.xml");
 
 using (var writer = new StreamWriter(filePath))
 {

--- a/src/Dataverse/templates/pp-app-security-role/.template.scripts/GenerateRolePrivileges.cs
+++ b/src/Dataverse/templates/pp-app-security-role/.template.scripts/GenerateRolePrivileges.cs
@@ -18,7 +18,11 @@ for (int i = 0; i < guids.Count; i++)
     guids[i] = guids[i].Trim();
 }
 
-var filePath = Path.Combine(".", "appaccess.xml");
+string scriptsDir = Path.GetFileName(Directory.GetCurrentDirectory()) == ".template.scripts"
+    ? Directory.GetCurrentDirectory()
+    : Path.Combine(Directory.GetCurrentDirectory(), ".template.scripts");
+Directory.CreateDirectory(scriptsDir);
+var filePath = Path.Combine(scriptsDir, "appaccess.xml");
 
 using (var writer = new StreamWriter(filePath))
 {

--- a/src/Dataverse/templates/pp-plugin-assembly-step/.template.scripts/AddFilteringAttributes.cs
+++ b/src/Dataverse/templates/pp-plugin-assembly-step/.template.scripts/AddFilteringAttributes.cs
@@ -6,7 +6,9 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 
 var json = "__filtering-attributes__";
-string outputRoot = Path.GetFullPath("..");
+string outputRoot = Path.GetFileName(Directory.GetCurrentDirectory()) == ".template.scripts"
+    ? Path.GetFullPath("..")
+    : Directory.GetCurrentDirectory();
 string xmlPath = Path.Combine(outputRoot, ".template.temp", "__step-id__.xml");
 
 string cleanedString = json

--- a/src/Dataverse/templates/pp-plugin-assembly-step/.template.scripts/AddFilteringAttributes.cs
+++ b/src/Dataverse/templates/pp-plugin-assembly-step/.template.scripts/AddFilteringAttributes.cs
@@ -6,7 +6,8 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 
 var json = "__filtering-attributes__";
-string xmlPath = ".template.temp/__step-id__.xml";
+string outputRoot = Path.GetFullPath("..");
+string xmlPath = Path.Combine(outputRoot, ".template.temp", "__step-id__.xml");
 
 string cleanedString = json
     .Trim('{', '}')                    

--- a/src/Dataverse/templates/pp-plugin-assembly/.template.scripts/GenerateAssembly.cs
+++ b/src/Dataverse/templates/pp-plugin-assembly/.template.scripts/GenerateAssembly.cs
@@ -20,7 +20,9 @@ XmlDocument csprojDoc = new XmlDocument();
 csprojDoc.Load(csprojPath);
 string assemblyName = csprojDoc.SelectNodes("//Project/PropertyGroup/AssemblyName").Cast<XmlNode>().LastOrDefault()?.InnerText ?? csprojFileName;
 string fileVersion = csprojDoc.SelectNodes("//Project/PropertyGroup/FileVersion").Cast<XmlNode>().LastOrDefault()?.InnerText ?? "1.0.0.0";
-string outputRoot = Path.GetFullPath("..");
+string outputRoot = Path.GetFileName(Directory.GetCurrentDirectory()) == ".template.scripts"
+    ? Path.GetFullPath("..")
+    : Directory.GetCurrentDirectory();
 string xmlPath = Path.Combine(outputRoot, "__solution-root-path__", "PluginAssemblies", $"{assemblyName}-{pluginAssemblyId.ToUpper()}", $"{assemblyName}.dll.data.xml");
 
 string dllPath = Path.Combine(pluginRootPath, "bin", "Debug", "net462", "publish", $"{assemblyName}.dll");

--- a/src/Dataverse/templates/pp-plugin-assembly/.template.scripts/GenerateAssembly.cs
+++ b/src/Dataverse/templates/pp-plugin-assembly/.template.scripts/GenerateAssembly.cs
@@ -20,7 +20,8 @@ XmlDocument csprojDoc = new XmlDocument();
 csprojDoc.Load(csprojPath);
 string assemblyName = csprojDoc.SelectNodes("//Project/PropertyGroup/AssemblyName").Cast<XmlNode>().LastOrDefault()?.InnerText ?? csprojFileName;
 string fileVersion = csprojDoc.SelectNodes("//Project/PropertyGroup/FileVersion").Cast<XmlNode>().LastOrDefault()?.InnerText ?? "1.0.0.0";
-string xmlPath = Path.Combine(Directory.GetCurrentDirectory(), "__solution-root-path__", "PluginAssemblies", $"{assemblyName}-{pluginAssemblyId.ToUpper()}", $"{assemblyName}.dll.data.xml");
+string outputRoot = Path.GetFullPath("..");
+string xmlPath = Path.Combine(outputRoot, "__solution-root-path__", "PluginAssemblies", $"{assemblyName}-{pluginAssemblyId.ToUpper()}", $"{assemblyName}.dll.data.xml");
 
 string dllPath = Path.Combine(pluginRootPath, "bin", "Debug", "net462", "publish", $"{assemblyName}.dll");
 if (!File.Exists(dllPath)) throw new FileNotFoundException("Build not found", dllPath);
@@ -93,9 +94,9 @@ solutionRoot.SetAttribute("behavior", "0");
 
 solutionDoc.AppendChild(solutionRoot);
 
-Directory.CreateDirectory(Path.Combine(Directory.GetCurrentDirectory(), ".template.temp"));
+Directory.CreateDirectory(Path.Combine(outputRoot, ".template.temp"));
 
-solutionDoc.Save(Path.Combine(".template.temp", "RootComponent.xml"));
+solutionDoc.Save(Path.Combine(outputRoot, ".template.temp", "RootComponent.xml"));
 
 
 


### PR DESCRIPTION
## Problem

`dotnet run --file` on .NET 10 sets `Environment.CurrentDirectory` to the .cs file's directory, not the caller's CWD. This breaks all template post-action scripts that use relative paths.

## Affected Templates

- `pp-app-security-role` — `Path.Combine(".", ".template.scripts", "appaccess.xml")` doubled the path since CWD is already `.template.scripts/`
- `pp-plugin-assembly` — `Directory.GetCurrentDirectory()` returned `.template.scripts/`, so assembly XML and `.template.temp/` were written to wrong location
- `pp-plugin-assembly-step` — relative path `.template.temp/__step-id__.xml` resolved under `.template.scripts/`

## Fix

Use `Path.GetFullPath("..")` to navigate from `.template.scripts/` up one level to the template output root before constructing paths. For `pp-app-security-role`, simply removed the redundant `.template.scripts` path segment since the file is already written from within that directory.