### PR TITLE
Add support for formula fields

### DIFF
--- a/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
@@ -159,10 +159,6 @@
       "defaultValue": "false",
       "isEnabled": "(AttributeType == \"Text\" || AttributeType == \"Decimal\" || AttributeType == \"WholeNumber\" || AttributeType == \"Float\" || AttributeType == \"Boolean\" || AttributeType == \"OptionSet(Local)\" || AttributeType == \"OptionSet(Global)\" || AttributeType == \"DateTime\")"
     },
-    "IsFormulaFieldComputed": {
-      "type": "computed",
-      "value": "(IsFormulaField)"
-    },
     "BooleanTrueLabel": {
       "type": "parameter",
       "description": "[Boolean] Label for the true/yes option.",
@@ -475,7 +471,7 @@
     
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
-      "condition": "(IsFormulaFieldComputed)",
+      "condition": "(IsFormulaField)",
       "args": {
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/InitFormulaDefinition.ps1\"",

--- a/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
@@ -18,6 +18,10 @@
 				{
 					"condition": "(!CreateGlobalOptionSet)",
 					"exclude": ["__solution-root-path__/OptionSets/*"]
+        },
+        {
+          "condition": "(!IsFormulaField)",
+          "exclude": ["__solution-root-path__/Entities/__entity-schema-name__/Formulas/__attribute-schema-name__.yaml"]
 				}
 			]
 		}
@@ -148,6 +152,13 @@
         { "choice": "2", "description": "Date only (no time component)" },
         { "choice": "3", "description": "Time zone independent (stores actual value)" }
       ]
+    },
+    "IsFormulaField": {
+      "type": "parameter",
+      "description": "[Text/Decimal/WholeNumber/Float/Boolean/Choice/DateTime] Set true to mark this column as a formula field. This sets SourceType to 3 and adds FormulaDefinitionFileName metadata.",
+      "datatype": "bool",
+      "defaultValue": false,
+      "isEnabled": "(AttributeType == \"Text\" || AttributeType == \"Decimal\" || AttributeType == \"WholeNumber\" || AttributeType == \"Float\" || AttributeType == \"Boolean\" || AttributeType == \"OptionSet(Local)\" || AttributeType == \"OptionSet(Global)\" || AttributeType == \"DateTime\")"
     },
     "BooleanTrueLabel": {
       "type": "parameter",

--- a/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
@@ -155,7 +155,7 @@
     },
     "IsFormulaField": {
       "type": "parameter",
-      "description": "[Text/Decimal/WholeNumber/Float/Boolean/Choice/DateTime] Set true to mark this column as a formula field. This sets SourceType to 3 and adds FormulaDefinitionFileName metadata.",
+      "description": "[Text/Decimal/WholeNumber/Float/Boolean/Choice/DateTime] Set true to mark this column as a formula field. This sets SourceType to 3, adds FormulaDefinitionFileName metadata pointing to Entities/{EntitySchemaName}/Formulas/{AttributeSchemaName}.yaml, and generates that YAML file as a placeholder. After scaffolding, populate the YAML file with the Power Fx formula expression under the 'prefix + logical name' key (e.g., 'uddp_formulafield: =ThisRecord.udpp_price * ThisRecord.udpp_quantity'). For multi-line formulas use |- (e.g. 'uddp_formulafield: |- =ThisRecord.udpp_price * ThisRecord.udpp_quantity'). Reference same-record columns via ThisRecord.column_logical_name. The formula's return type must match the chosen AttributeType (e.g., a Decimal formula for a Decimal column). Supported operators: +, -, *, /, %, in, exactin, &. Use Power Fx functions such as If, Switch, Concatenate, Text, DateAdd, UTCNow, etc.",
       "datatype": "bool",
       "defaultValue": "false",
       "isEnabled": "(AttributeType == \"Text\" || AttributeType == \"Decimal\" || AttributeType == \"WholeNumber\" || AttributeType == \"Float\" || AttributeType == \"Boolean\" || AttributeType == \"OptionSet(Local)\" || AttributeType == \"OptionSet(Global)\" || AttributeType == \"DateTime\")"

--- a/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
@@ -20,9 +20,8 @@
 					"exclude": ["__solution-root-path__/OptionSets/*"]
         },
         {
-          "condition": "(!IsFormulaFieldComputed)",
-          "exclude": ["__solution-root-path__/Entities/__entity-schema-name__/Formulas/__attribute-schema-name__.yaml"]
-				}
+          "exclude": ["__solution-root-path__/Entities/__entity-schema-name__/Formulas/__entity-schema-name__-FormulaDefinitions.yaml"]
+        }
 			]
 		}
 	],
@@ -155,7 +154,7 @@
     },
     "IsFormulaField": {
       "type": "parameter",
-      "description": "[Text/Decimal/WholeNumber/Float/Boolean/Choice/DateTime] Set true to mark this column as a formula field. This sets SourceType to 3, adds FormulaDefinitionFileName metadata pointing to Entities/{EntitySchemaName}/Formulas/{AttributeSchemaName}.yaml, and generates that YAML file as a placeholder. After scaffolding, populate the YAML file with the Power Fx formula expression under the 'prefix + logical name' key (e.g., 'uddp_formulafield: =ThisRecord.udpp_price * ThisRecord.udpp_quantity'). For multi-line formulas use |- (e.g. 'uddp_formulafield: |- =ThisRecord.udpp_price * ThisRecord.udpp_quantity'). Reference same-record columns via ThisRecord.column_logical_name. The formula's return type must match the chosen AttributeType (e.g., a Decimal formula for a Decimal column). Supported operators: +, -, *, /, %, in, exactin, &. Use Power Fx functions such as If, Switch, Concatenate, Text, DateAdd, UTCNow, etc.",
+      "description": "[Text/Decimal/WholeNumber/Float/Boolean/Choice/DateTime] Set true to mark this column as a formula field. This sets SourceType to 3, sets ValidForCreate/UpdateApi to 0 (read-only), adds FormulaDefinitionFileName metadata pointing to Entities/{EntitySchemaName}/Formulas/{EntitySchemaName}-FormulaDefinitions.yaml, and creates or appends to that consolidated YAML file with a placeholder entry. After scaffolding, fill in the Power Fx expression after the colon (e.g., 'ntg_totalamount: =ThisRecord.ntg_price * ThisRecord.ntg_quantity'). For multi-line formulas use '|-'. Reference same-record columns via ThisRecord.column_logical_name. The formula's return type must match the chosen AttributeType. Supported operators: +, -, *, /, %, in, exactin, &. Use Power Fx functions such as If, Switch, Concatenate, Text, DateAdd, UTCNow, etc.",
       "datatype": "bool",
       "defaultValue": "false",
       "isEnabled": "(AttributeType == \"Text\" || AttributeType == \"Decimal\" || AttributeType == \"WholeNumber\" || AttributeType == \"Float\" || AttributeType == \"Boolean\" || AttributeType == \"OptionSet(Local)\" || AttributeType == \"OptionSet(Global)\" || AttributeType == \"DateTime\")"
@@ -474,6 +473,20 @@
       "description": "Adding lookup relationship xml"
     },
     
+    {
+      "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
+      "condition": "(IsFormulaFieldComputed)",
+      "args": {
+        "executable": "pwsh",
+        "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/InitFormulaDefinition.ps1\"",
+        "redirectStandardOutput": "false"
+      },
+      "manualInstructions": [
+        { "text": "Initializing formula definition YAML" }
+      ],
+      "continueOnError": false,
+      "description": "Initializing formula definition YAML"
+    },
     {
       "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
       "args": {

--- a/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
@@ -20,7 +20,7 @@
 					"exclude": ["__solution-root-path__/OptionSets/*"]
         },
         {
-          "condition": "(!IsFormulaField)",
+          "condition": "(!IsFormulaFieldComputed)",
           "exclude": ["__solution-root-path__/Entities/__entity-schema-name__/Formulas/__attribute-schema-name__.yaml"]
 				}
 			]
@@ -157,8 +157,12 @@
       "type": "parameter",
       "description": "[Text/Decimal/WholeNumber/Float/Boolean/Choice/DateTime] Set true to mark this column as a formula field. This sets SourceType to 3 and adds FormulaDefinitionFileName metadata.",
       "datatype": "bool",
-      "defaultValue": false,
+      "defaultValue": "false",
       "isEnabled": "(AttributeType == \"Text\" || AttributeType == \"Decimal\" || AttributeType == \"WholeNumber\" || AttributeType == \"Float\" || AttributeType == \"Boolean\" || AttributeType == \"OptionSet(Local)\" || AttributeType == \"OptionSet(Global)\" || AttributeType == \"DateTime\")"
+    },
+    "IsFormulaFieldComputed": {
+      "type": "computed",
+      "value": "(IsFormulaField)"
     },
     "BooleanTrueLabel": {
       "type": "parameter",

--- a/src/Dataverse/templates/pp-entity-attribute/.template.scripts/InitFormulaDefinition.ps1
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.scripts/InitFormulaDefinition.ps1
@@ -1,0 +1,27 @@
+$ErrorActionPreference = 'Stop'
+
+$formulasDir = (Resolve-Path '__solution-root-path__/Entities/__entity-schema-name__/Formulas' -ErrorAction SilentlyContinue)?.Path
+$yamlPath    = Join-Path ($formulasDir ?? (Join-Path '__solution-root-path__' 'Entities' '__entity-schema-name__' 'Formulas')) '__entity-schema-name__-FormulaDefinitions.yaml'
+$entryKey    = '__attribute-schema-name__:'
+
+# Create directory if it doesn't exist
+if (-not (Test-Path (Split-Path $yamlPath))) {
+    New-Item -ItemType Directory -Path (Split-Path $yamlPath) -Force | Out-Null
+}
+
+if (Test-Path $yamlPath) {
+    # File exists — check if this attribute's entry is already present
+    $content = Get-Content $yamlPath -Raw
+    $escapedKey = [regex]::Escape($entryKey)
+    if ($content -notmatch "(^|`n)$escapedKey") {
+        # Append new placeholder entry for the user to fill in
+        Add-Content -Path $yamlPath -Value "${entryKey} "
+        Write-Host "Appended formula placeholder for '$entryKey' in '$yamlPath'. Fill in the Power Fx expression after the colon."
+    } else {
+        Write-Host "Formula entry for '$entryKey' already exists in '$yamlPath'. Skipping."
+    }
+} else {
+    # File doesn't exist — create it with the first placeholder entry
+    Set-Content -Path $yamlPath -Value "${entryKey} "
+    Write-Host "Created '$yamlPath' with formula placeholder for '$entryKey'. Fill in the Power Fx expression after the colon."
+}

--- a/src/Dataverse/templates/pp-entity-attribute/.template.temp/attribute.xml
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.temp/attribute.xml
@@ -81,7 +81,11 @@
     <CanModifyRequirementLevelSettings>1</CanModifyRequirementLevelSettings>
     <!--#endif -->
     <CanModifyAdditionalSettings>1</CanModifyAdditionalSettings>
+    <!--#if (IsFormulaField) -->
+    <SourceType>3</SourceType>
+    <!--#else -->
     <SourceType>0</SourceType>
+    <!--#endif -->
     <!--#if (AttributeType == "Image") -->
     <IsLogical>1</IsLogical>
     <!--#endif -->
@@ -215,4 +219,7 @@
     <Descriptions>
         <Description description="__attribute-description__" languagecode="1033" />
     </Descriptions>
+    <!--#if (IsFormulaField) -->
+    <FormulaDefinitionFileName>/Formulas/__attribute-schema-name__.yaml</FormulaDefinitionFileName>
+    <!--#endif -->
 </attribute>

--- a/src/Dataverse/templates/pp-entity-attribute/.template.temp/attribute.xml
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.temp/attribute.xml
@@ -53,13 +53,13 @@
     <!--#else -->
     <ImeMode>auto</ImeMode>
     <!--#endif -->
-    <!--#if (AttributeType == "File" || IsFormulaFieldComputed) -->
+    <!--#if (AttributeType == "File" || IsFormulaField) -->
     <ValidForUpdateApi>0</ValidForUpdateApi>
     <!--#else -->
     <ValidForUpdateApi>1</ValidForUpdateApi>
     <!--#endif -->
     <ValidForReadApi>1</ValidForReadApi>
-    <!--#if (AttributeType == "File" || IsFormulaFieldComputed) -->
+    <!--#if (AttributeType == "File" || IsFormulaField) -->
     <ValidForCreateApi>0</ValidForCreateApi>
     <!--#else -->
     <ValidForCreateApi>1</ValidForCreateApi>
@@ -81,7 +81,7 @@
     <CanModifyRequirementLevelSettings>1</CanModifyRequirementLevelSettings>
     <!--#endif -->
     <CanModifyAdditionalSettings>1</CanModifyAdditionalSettings>
-    <!--#if (IsFormulaFieldComputed) -->
+    <!--#if (IsFormulaField) -->
     <SourceType>3</SourceType>
     <!--#else -->
     <SourceType>0</SourceType>
@@ -219,7 +219,7 @@
     <Descriptions>
         <Description description="__attribute-description__" languagecode="1033" />
     </Descriptions>
-    <!--#if (IsFormulaFieldComputed) -->
+    <!--#if (IsFormulaField) -->
     <FormulaDefinitionFileName>/Formulas/__entity-schema-name__-FormulaDefinitions.yaml</FormulaDefinitionFileName>
     <!--#endif -->
 </attribute>

--- a/src/Dataverse/templates/pp-entity-attribute/.template.temp/attribute.xml
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.temp/attribute.xml
@@ -81,7 +81,7 @@
     <CanModifyRequirementLevelSettings>1</CanModifyRequirementLevelSettings>
     <!--#endif -->
     <CanModifyAdditionalSettings>1</CanModifyAdditionalSettings>
-    <!--#if (IsFormulaField) -->
+    <!--#if (IsFormulaFieldComputed) -->
     <SourceType>3</SourceType>
     <!--#else -->
     <SourceType>0</SourceType>
@@ -219,7 +219,7 @@
     <Descriptions>
         <Description description="__attribute-description__" languagecode="1033" />
     </Descriptions>
-    <!--#if (IsFormulaField) -->
+    <!--#if (IsFormulaFieldComputed) -->
     <FormulaDefinitionFileName>/Formulas/__attribute-schema-name__.yaml</FormulaDefinitionFileName>
     <!--#endif -->
 </attribute>

--- a/src/Dataverse/templates/pp-entity-attribute/.template.temp/attribute.xml
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.temp/attribute.xml
@@ -53,13 +53,13 @@
     <!--#else -->
     <ImeMode>auto</ImeMode>
     <!--#endif -->
-    <!--#if (AttributeType == "File") -->
+    <!--#if (AttributeType == "File" || IsFormulaFieldComputed) -->
     <ValidForUpdateApi>0</ValidForUpdateApi>
     <!--#else -->
     <ValidForUpdateApi>1</ValidForUpdateApi>
     <!--#endif -->
     <ValidForReadApi>1</ValidForReadApi>
-    <!--#if (AttributeType == "File") -->
+    <!--#if (AttributeType == "File" || IsFormulaFieldComputed) -->
     <ValidForCreateApi>0</ValidForCreateApi>
     <!--#else -->
     <ValidForCreateApi>1</ValidForCreateApi>
@@ -220,6 +220,6 @@
         <Description description="__attribute-description__" languagecode="1033" />
     </Descriptions>
     <!--#if (IsFormulaFieldComputed) -->
-    <FormulaDefinitionFileName>/Formulas/__attribute-schema-name__.yaml</FormulaDefinitionFileName>
+    <FormulaDefinitionFileName>/Formulas/__entity-schema-name__-FormulaDefinitions.yaml</FormulaDefinitionFileName>
     <!--#endif -->
 </attribute>

--- a/src/Dataverse/templates/pp-entity-attribute/__solution-root-path__/Entities/__entity-schema-name__/Formulas/__entity-schema-name__-FormulaDefinitions.yaml
+++ b/src/Dataverse/templates/pp-entity-attribute/__solution-root-path__/Entities/__entity-schema-name__/Formulas/__entity-schema-name__-FormulaDefinitions.yaml
@@ -1,0 +1,1 @@
+__attribute-schema-name__: 


### PR DESCRIPTION
This pull request adds support for marking entity attributes as formula fields in the Dataverse Power Platform entity attribute template. The changes introduce a new `IsFormulaField` parameter that, when enabled, sets the appropriate metadata and includes a formula definition file for the attribute.

Enhancements for formula field support:

* Added a new boolean parameter `IsFormulaField` to `template.json`, allowing users to specify if an attribute is a formula field. This parameter is only enabled for supported attribute types and sets relevant metadata when true.
* Updated file exclusion rules in `template.json` so that the formula definition YAML file is only included when `IsFormulaField` is true.

Template rendering logic updates:

* Modified `attribute.xml` to set `<SourceType>` to `3` for formula fields and to `0` otherwise, based on the `IsFormulaField` parameter.
* Added conditional inclusion of `<FormulaDefinitionFileName>` in `attribute.xml` when the attribute is a formula field.