### PR TITLE
refactor: templates were refactored to match the TALXIS SDK style.

### DIFF
--- a/src/Dataverse/templates/pp-plugin-assembly-step/.template.config/template.json
+++ b/src/Dataverse/templates/pp-plugin-assembly-step/.template.config/template.json
@@ -207,6 +207,7 @@
     "FilteringAttributes": {
       "type": "parameter",
       "datatype": "text",
+      "defaultValue": "",
       "replaces": "__filtering-attributes__",
       "description": "Comma-separated list of entity fields that must change to trigger the plugin (leave empty to run on any field change)"
     }

--- a/src/Dataverse/templates/pp-plugin-assembly/.template.scripts/GenerateAssembly.cs
+++ b/src/Dataverse/templates/pp-plugin-assembly/.template.scripts/GenerateAssembly.cs
@@ -23,7 +23,7 @@ string fileVersion = csprojDoc.SelectNodes("//Project/PropertyGroup/FileVersion"
 string outputRoot = Path.GetFileName(Directory.GetCurrentDirectory()) == ".template.scripts"
     ? Path.GetFullPath("..")
     : Directory.GetCurrentDirectory();
-string xmlPath = Path.Combine(outputRoot, "__solution-root-path__", "PluginAssemblies", $"{assemblyName}-{pluginAssemblyId.ToUpper()}", $"{assemblyName}.dll.data.xml");
+string xmlPath = Path.Combine(outputRoot, "__solution-root-path__", "PluginAssemblies", $"{assemblyName}.dll.data.xml");
 
 string dllPath = Path.Combine(pluginRootPath, "bin", "Debug", "net462", "publish", $"{assemblyName}.dll");
 if (!File.Exists(dllPath)) throw new FileNotFoundException("Build not found", dllPath);
@@ -63,7 +63,7 @@ sourceType.InnerText = "0";
 root.AppendChild(sourceType);
 
 XmlElement fileName = pluginDoc.CreateElement("FileName");
-fileName.InnerText = $"/PluginAssemblies/{assemblyName}-{pluginAssemblyId.ToUpper()}/{assemblyName}.dll";
+fileName.InnerText = $"/PluginAssemblies/{assemblyName}.dll";
 root.AppendChild(fileName);
 
 XmlElement pluginTypes = pluginDoc.CreateElement("PluginTypes");

--- a/src/Dataverse/templates/pp-plugin/.template.config/template.json
+++ b/src/Dataverse/templates/pp-plugin/.template.config/template.json
@@ -53,7 +53,7 @@
     "SigningKeyFilePath": {
       "type": "parameter",
       "datatype": "text",
-      "isRequired": true,
+      "isRequired": false,
       "replaces": "signingkeyfilepathexample",
       "description": "Path to the signing key file for plugin assembly signing (optional)"
     }

--- a/src/Dataverse/templates/pp-plugin/.template.scripts/InitializePlugin.ps1
+++ b/src/Dataverse/templates/pp-plugin/.template.scripts/InitializePlugin.ps1
@@ -42,31 +42,12 @@ if (-not $firstPropertyGroup) {
     $firstPropertyGroup = $csproj.CreateElement("PropertyGroup", $namespaceUri)
     $csproj.Project.PrependChild($firstPropertyGroup) | Out-Null
 }
-$projectTypeElement = $firstPropertyGroup.ProjectType
-if (-not $projectTypeElement) {
-    $projectTypeElement = $csproj.CreateElement("ProjectType", $namespaceUri)
-    $projectTypeElement.InnerText = "Plugin"
-    $firstPropertyGroup.AppendChild($projectTypeElement) | Out-Null
-} else {
-    $projectTypeElement.InnerText = "Plugin"
-}
 
 # --- 8. Find or create a PropertyGroup ---
 $propertyGroup = $csproj.Project.PropertyGroup | Where-Object { $_.AssemblyName -or $_.TargetFramework }
 if (-not $propertyGroup) {
     $propertyGroup = $csproj.CreateElement("PropertyGroup", $namespaceUri)
     $csproj.Project.AppendChild($propertyGroup) | Out-Null
-}
-
-# --- 9. Remove existing AssemblyName and PackageId ---
-$csproj.Project.PropertyGroup.AssemblyName | ForEach-Object {
-    $_.ParentNode.RemoveChild($_) | Out-Null
-}
-$csproj.Project.PropertyGroup.PackageId | ForEach-Object {
-    $_.ParentNode.RemoveChild($_) | Out-Null
-}
-$csproj.Project.PropertyGroup.Company | ForEach-Object {
-    $_.ParentNode.RemoveChild($_) | Out-Null
 }
 
 # --- 10. Add new AssemblyName and PackageId ---
@@ -84,15 +65,7 @@ $companyElement = $csproj.CreateElement("Company", $namespaceUri)
 $companyElement.InnerText = $company
 $propertyGroup.AppendChild($companyElement) | Out-Null
 
-# --- 13. Save changes back to the .csproj file ---
-$csproj.Save($ProjectPath)
-
-# --- 14. Copy the PluginBase.cs file to the project ---
-if ("pluginbasetypeexample" -eq "TALXIS") {
-    Copy-Item ".template.temp/PluginBase.cs" -Destination . -Force
-}
-
-# --- 15. Generate SNK file if it doesn't exist (cross-platform, no sn.exe needed) ---
+# --- 13. Generate SNK file if it doesn't exist (cross-platform, no sn.exe needed) ---
 $snkPath = $signingKey
 if (-not (Test-Path $snkPath)) {
     Write-Host "Generating strong name key file: $signingKey"
@@ -112,6 +85,21 @@ public static class SnkGenerator {
 }
 "@
     Add-Type -TypeDefinition $csharp -Language CSharp -ErrorAction Stop
-    [SnkGenerator]::Create($snkPath)
+    $snkPath = "AssemblyOriginatorKeyFile.snk"
+    [SnkGenerator]::Create("$snkPath")
     Write-Host "Generated SNK file at: $snkPath"
 }
+
+
+$assemblyNameElement = $csproj.CreateElement("AssemblyOriginatorKeyFile", $namespaceUri)
+$assemblyNameElement.InnerText = $snkPath
+$propertyGroup.AppendChild($assemblyNameElement) | Out-Null
+
+# --- 14. Save changes back to the .csproj file ---
+$csproj.Save($ProjectPath)
+
+# --- 15. Copy the PluginBase.cs file to the project ---
+if ("pluginbasetypeexample" -eq "TALXIS") {
+    Copy-Item ".template.temp/PluginBase.cs" -Destination . -Force
+}
+

--- a/src/Dataverse/templates/pp-plugin/SolutionLogicalNameExample.csproj
+++ b/src/Dataverse/templates/pp-plugin/SolutionLogicalNameExample.csproj
@@ -2,11 +2,9 @@
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>signingkeyfilepathexample</AssemblyOriginatorKeyFile>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
     <ProjectType>Plugin</ProjectType>
-    <Company>exampleсompany</Company>
   </PropertyGroup>
   <!--
     NuGet pack and restore as MSBuild targets reference:


### PR DESCRIPTION
Automatic SNK key generation has been configured, and the metadata files are generated in the locations where the TALXIS SDK expects them.