### PR TITLE
fix: resolve post-action script path issues in pp-plugin-assembly and pp-security-role-privilege

### DIFF
--- a/src/Dataverse/templates/pp-plugin-assembly/.template.scripts/GenerateAssembly.cs
+++ b/src/Dataverse/templates/pp-plugin-assembly/.template.scripts/GenerateAssembly.cs
@@ -7,9 +7,15 @@ using System.Collections.Generic;
 
 string pluginRootPath = @"__plugin-project-root__";
 string pluginAssemblyId = "__assembly-id__";
+string outputRoot = Path.GetFileName(Directory.GetCurrentDirectory()) == ".template.scripts"
+    ? Path.GetFullPath("..")
+    : Directory.GetCurrentDirectory();
+string resolvedPluginRootPath = Path.IsPathRooted(pluginRootPath)
+    ? Path.GetFullPath(pluginRootPath)
+    : Path.GetFullPath(Path.Combine(outputRoot, pluginRootPath));
 
 
-string csprojPath = Directory.GetFiles(pluginRootPath, "*.csproj").FirstOrDefault();
+string csprojPath = Directory.GetFiles(resolvedPluginRootPath, "*.csproj").FirstOrDefault();
 if (csprojPath == null) throw new Exception("csproj not found");
 string projectDirectory = Path.GetDirectoryName(csprojPath);
 string sdkPath = Path.Combine(projectDirectory, "bin", "Debug", "net462", "Microsoft.Xrm.Sdk.dll"); 
@@ -20,12 +26,9 @@ XmlDocument csprojDoc = new XmlDocument();
 csprojDoc.Load(csprojPath);
 string assemblyName = csprojDoc.SelectNodes("//Project/PropertyGroup/AssemblyName").Cast<XmlNode>().LastOrDefault()?.InnerText ?? csprojFileName;
 string fileVersion = csprojDoc.SelectNodes("//Project/PropertyGroup/FileVersion").Cast<XmlNode>().LastOrDefault()?.InnerText ?? "1.0.0.0";
-string outputRoot = Path.GetFileName(Directory.GetCurrentDirectory()) == ".template.scripts"
-    ? Path.GetFullPath("..")
-    : Directory.GetCurrentDirectory();
 string xmlPath = Path.Combine(outputRoot, "__solution-root-path__", "PluginAssemblies", $"{assemblyName}.dll.data.xml");
 
-string dllPath = Path.Combine(pluginRootPath, "bin", "Debug", "net462", "publish", $"{assemblyName}.dll");
+string dllPath = Path.Combine(resolvedPluginRootPath, "bin", "Debug", "net462", "publish", $"{assemblyName}.dll");
 if (!File.Exists(dllPath)) throw new FileNotFoundException("Build not found", dllPath);
 
 Assembly pluginAssembly = Assembly.LoadFrom(dllPath);
@@ -99,6 +102,5 @@ solutionDoc.AppendChild(solutionRoot);
 Directory.CreateDirectory(Path.Combine(outputRoot, ".template.temp"));
 
 solutionDoc.Save(Path.Combine(outputRoot, ".template.temp", "RootComponent.xml"));
-
 
 

--- a/src/Dataverse/templates/pp-security-role-privilege/.template.scripts/GenerateRolePrivileges.cs
+++ b/src/Dataverse/templates/pp-security-role-privilege/.template.scripts/GenerateRolePrivileges.cs
@@ -16,7 +16,11 @@ var permissions = JsonSerializer.Deserialize<List<Privilege>>(fixedJson, new Jso
     TypeInfoResolver = new DefaultJsonTypeInfoResolver()
 });
 
-var filePath = Path.Combine(".", "privileges.xml");
+string scriptsDir = Path.GetFileName(Directory.GetCurrentDirectory()) == ".template.scripts"
+    ? Directory.GetCurrentDirectory()
+    : Path.Combine(Directory.GetCurrentDirectory(), ".template.scripts");
+Directory.CreateDirectory(scriptsDir);
+var filePath = Path.Combine(scriptsDir, "privileges.xml");
 
 using (var writer = new StreamWriter(filePath))
 {


### PR DESCRIPTION
## Summary
This fixes two post-action path resolution bugs first documented on 2026-04-28 (txc v1.9.0) and confirmed again on 2026-06-29 against templates v1.23.0.

## What was broken
1. `pp-security-role-privilege`
   - `AddPrivilegesToSecurityRole.ps1` expects `.template.scripts/privileges.xml`
   - but `GenerateRolePrivileges.cs` could write `privileges.xml` into the template output root instead
   - result: `Resolve-Path '.template.scripts/privileges.xml'` fails

2. `pp-plugin-assembly`
   - `GenerateAssembly.cs` already normalizes the output root for `.template.temp` / generated solution files
   - but it still used raw `PluginProjectRootPath` for csproj/DLL lookup
   - when `dotnet run --file` executes from `.template.scripts`, a relative value like `../Plugins.Warehouse` is resolved from the wrong base directory
   - result: the script looks under `src/Solutions.Logic/Plugins.Warehouse` instead of `src/Plugins.Warehouse`

## Root cause
`dotnet run --file` child scripts do not reliably operate from the template output root. In this repo, similar templates already guard against that:
- `pp-app-security-role` writes its temp XML into `.template.scripts`
- `pp-plugin-assembly-step` derives `outputRoot` before touching `.template.temp`

These two templates were the remaining inconsistent cases:
- `pp-security-role-privilege` producer/consumer disagreed on where `privileges.xml` lives
- `pp-plugin-assembly` normalized output paths, but not the relative plugin project input path

## Fixes
- `pp-security-role-privilege`: align `GenerateRolePrivileges.cs` with the existing repo pattern and always write `privileges.xml` into `.template.scripts/`
- `pp-plugin-assembly`: resolve `PluginProjectRootPath` against the normalized template output root before reading the csproj or published DLL

## Reproduction / evidence
### Historical run (2026-04-28, txc v1.9.0)
- `pp-security-role-privilege`: `.template.scripts/AddPrivilegesToSecurityRole.ps1` failed with `Cannot find path '.template.scripts/privileges.xml'`
- `pp-plugin-assembly`: `AddAssemblyToSolution.ps1` failed with `Cannot find path '.template.temp/RootComponent.xml'`

### Current run (2026-06-29, templates v1.23.0)
- `pp-security-role-privilege`: same `Resolve-Path '.template.scripts/privileges.xml'` failure confirmed again
- `pp-plugin-assembly`: `GenerateAssembly.cs` threw:
  ```text
  System.IO.DirectoryNotFoundException: Could not find a part of the path '/Users/tomasprokop/Desktop/Experiments/eppc26-testing/src/Solutions.Logic/Plugins.Warehouse'
  ```
  with `PluginProjectRootPath=../Plugins.Warehouse` and output `src/Solutions.Logic`, even though the actual plugin project was at `src/Plugins.Warehouse`

## Validation
- `dotnet pack --configuration Debug`
- `dotnet new install src/Dataverse/bin/Debug/TALXIS.DevKit.Templates.Dataverse.0.0.1.nupkg --force`
- `dotnet new pp-security-role-privilege --help`
- `dotnet new pp-plugin-assembly --help`
