### PR TITLE
fix(pp-test-ui): add missing sitemap click and view assertion step definitions

### DIFF
--- a/src/Dataverse/templates/pp-test-ui/Support/Bindings/NavigationSteps.cs
+++ b/src/Dataverse/templates/pp-test-ui/Support/Bindings/NavigationSteps.cs
@@ -42,6 +42,12 @@ public sealed class NavigationSteps
         await ClickSitemapItemAsync(subarea);
     }
 
+    [When("I click on {string} in the sitemap")]
+    public async Task WhenIClickOnInTheSitemap(string name)
+    {
+        await ClickSitemapItemAsync(name);
+    }
+
     [When("I switch to the {string} app")]
     public async Task WhenISwitchToTheApp(string appName)
     {

--- a/src/Dataverse/templates/pp-test-ui/Support/Bindings/ViewSteps.cs
+++ b/src/Dataverse/templates/pp-test-ui/Support/Bindings/ViewSteps.cs
@@ -62,6 +62,23 @@ public sealed class ViewSteps
         await Page.GetByRole(AriaRole.Columnheader, new PageGetByRoleOptions { Name = columnLabel }).ClickAsync();
     }
 
+    [Then("I should see the {string} view")]
+    public async Task ThenIShouldSeeTheView(string viewName)
+    {
+        var viewSelector = Page.Locator("[data-id*='ViewSelector'], button[data-id*='ViewSelector']").First;
+
+        await viewSelector.WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+            Timeout = TestConfiguration.Timeout
+        });
+
+        var currentViewName = (await viewSelector.TextContentAsync())?.Trim() ?? string.Empty;
+        Assert.IsTrue(
+            currentViewName.Contains(viewName, StringComparison.OrdinalIgnoreCase),
+            $"Expected the current view to contain '{viewName}', but found '{currentViewName}'.");
+    }
+
     [Then("the grid should contain {int} records")]
     public async Task ThenTheGridShouldContainRecords(int count)
     {


### PR DESCRIPTION
## Summary

Adds two missing Reqnroll step bindings to the `pp-test-ui` template that are referenced in the generated `WarehouseItemNavigation.feature` scenario but not included in the base step library.

## Missing steps added

**NavigationSteps.cs**:
```gherkin
When I click on 'Warehouse Items' in the sitemap
```

**ViewSteps.cs**:
```gherkin
Then I should see the 'Active Warehouse Items' view
```

## Root cause
The `WarehouseItemNavigation.feature` generated by `pp-test-ui-feature` (or the default feature) uses these steps, but the base bindings only covered multi-level navigation (`When I navigate to {area} > {subarea}`). Single-level sitemap clicks and view name assertions were missing.

## Test impact
Before: 12/13 BDD tests pass (1 undefined step)  
After: 13/13 BDD tests pass

Discovered during regression testing of tools-cli v1.18.0 + tools-devkit-templates v1.23.0.