### PR TITLE
fix(pp-test-ui): update frozen vocabulary tests for new step definitions

### DIFF
--- a/src/Dataverse/templates/pp-test-ui/Tests/BindingPatternTests.cs
+++ b/src/Dataverse/templates/pp-test-ui/Tests/BindingPatternTests.cs
@@ -17,7 +17,8 @@ public sealed class BindingPatternTests
                 "When:I navigate to {string} > {string}",
                 "When:I navigate to {string} > {string} > {string}",
                 "When:I switch to the {string} app",
-                "When:I search for {string} in global search"
+                "When:I search for {string} in global search",
+                "When:I click on {string} in the sitemap"
             ]);
 
     [TestMethod]
@@ -63,7 +64,8 @@ public sealed class BindingPatternTests
                 "When:I search for {string} in the grid",
                 "When:I sort the grid by {string}",
                 "Then:the grid should contain {int} records",
-                "Then:the grid should contain a record with {string} equal to {string}"
+                "Then:the grid should contain a record with {string} equal to {string}",
+                "Then:I should see the {string} view"
             ]);
 
     [TestMethod]


### PR DESCRIPTION
Follow-up to #120.

Updates `BindingPatternTests.cs` frozen vocabulary to include the two new step bindings added in #120:
- `When:I click on {string} in the sitemap`
- `Then:I should see the {string} view`

Without this fix, the `ViewSteps_match_the_frozen_vocabulary` and `NavigationSteps_match_the_frozen_vocabulary` tests fail with a count mismatch (expected 7, actual 8).

**Verified**: 13/13 BDD tests pass against a live Dataverse environment after this fix.