### PR TITLE
fix(templates): use registered RunScript action ID for NormalizeNilTags

### DIFF
--- a/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity-attribute/.template.config/template.json
@@ -473,7 +473,7 @@
       "description": "Sorting entity attributes"
     },
     {
-      "actionId": "7D61D1F8-0E07-4CB7-9D51-84B9F04E3F6A",
+      "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
       "args": {
         "executable": "pwsh",
         "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/NormalizeNilTags.ps1\"",

--- a/src/Dataverse/templates/pp-entity/.template.config/template.json
+++ b/src/Dataverse/templates/pp-entity/.template.config/template.json
@@ -843,7 +843,7 @@
 			"description": "Sorting entity attributes"
 		},
 		{
-			"actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B98E",
+			"actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
 			"args": {
 				"executable": "pwsh",
 				"args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/NormalizeNilTags.ps1\"",


### PR DESCRIPTION
## Problem
PR #123 introduced `NormalizeNilTags` post-actions to reduce first-pull git noise, but used **invented action IDs**:
- `pp-entity`: `3A7C4B45-1F5D-4A30-959A-51B88E82B98E`
- `pp-entity-attribute`: `7D61D1F8-0E07-4CB7-9D51-84B9F04E3F6A`

Neither is registered in txc's `PostActionDispatcher` (only RunScript `...82B5D2`, AddReference, AddProjectsToSln are). Scaffolding an entity fails with:
```
Post-action 'Normalizing xsi:nil tags in solution.xml' is not supported.
```
This broke entity scaffolding in the agentbox image / EPPC ALM lab.

## Fix
Point both NormalizeNilTags post-actions at the real RunScript GUID `3A7C4B45-1F5D-4A30-959A-51B88E82B5D2`.

## Verified
- JSON valid; package packs.
- `dotnet new pp-entity` post-action now runs: 'Running command pwsh ... NormalizeNilTags.ps1' → 'Command succeeded' (was 'not supported').