### PR TITLE
chore: drop explicit net462 TargetFramework from scaffolded csproj

### DIFF
--- a/src/Dataverse/templates/pp-app-code/CodeAppExample.csproj
+++ b/src/Dataverse/templates/pp-app-code/CodeAppExample.csproj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="TALXIS.DevKit.Build.Sdk/1.6.1">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
     <AppName>codeappexample</AppName>
     <ProjectType>CodeApp</ProjectType>
   </PropertyGroup>

--- a/src/Dataverse/templates/pp-page-generative/__project-name__.csproj
+++ b/src/Dataverse/templates/pp-page-generative/__project-name__.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="TALXIS.DevKit.Build.Sdk/1.6.1">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
     <ProjectType>GenPage</ProjectType>
     <GenPageName>__genpage-name__</GenPageName>
     <GenPageId>__genpage-id__</GenPageId>

--- a/src/Dataverse/templates/pp-pcf/examplesourcename.csproj
+++ b/src/Dataverse/templates/pp-pcf/examplesourcename.csproj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="TALXIS.DevKit.Build.Sdk/1.6.1">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
     <Name>examplesourcename</Name>
     <ProjectGuid>56daf92d-4098-4de0-9ba5-0fa2f9e3d36b</ProjectGuid>
     <OutputPath>$(MSBuildThisFileDirectory)out\controls</OutputPath>

--- a/src/Dataverse/templates/pp-plugin/SolutionLogicalNameExample.csproj
+++ b/src/Dataverse/templates/pp-plugin/SolutionLogicalNameExample.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="TALXIS.DevKit.Build.Sdk/1.6.1">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>

--- a/src/Dataverse/templates/pp-script-library/__project-name__.csproj
+++ b/src/Dataverse/templates/pp-script-library/__project-name__.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="TALXIS.DevKit.Build.Sdk/1.6.1">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
     <ProjectType>ScriptLibrary</ProjectType>
     <ScriptLibraryName>__publisher-prefix_____library-name__</ScriptLibraryName>
     <TypeScriptDir>$(MSBuildProjectDirectory)</TypeScriptDir>

--- a/src/Dataverse/templates/pp-solution/SolutionLogicalNameExample.csproj
+++ b/src/Dataverse/templates/pp-solution/SolutionLogicalNameExample.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="TALXIS.DevKit.Build.Sdk/1.6.1">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
     <SolutionRootPath>__solution-root-path__</SolutionRootPath>
     <ProjectType>Solution</ProjectType>
     <GeneratePluginAssembly>generateexamplepluginassembly</GeneratePluginAssembly>

--- a/src/Dataverse/templates/pp-workflow-activity/.template.scripts/InitializePlugin.ps1
+++ b/src/Dataverse/templates/pp-workflow-activity/.template.scripts/InitializePlugin.ps1
@@ -49,7 +49,6 @@ $signingKeyLine = if ($useSigningKey) { "    <AssemblyOriginatorKeyFile>$signing
 $csprojText = @"
 <Project Sdk="TALXIS.DevKit.Build.Sdk/1.6.1">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
     <LangVersion>latest</LangVersion>
     <SignAssembly>$signAssemblyValue</SignAssembly>
 $signingKeyLine    <AssemblyVersion>1.0.0.0</AssemblyVersion>

--- a/src/Dataverse/templates/pp-workflow-activity/SolutionLogicalNameExample.csproj
+++ b/src/Dataverse/templates/pp-workflow-activity/SolutionLogicalNameExample.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="TALXIS.DevKit.Build.Sdk/1.6.1">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
     <LangVersion>latest</LangVersion>
     <SignAssembly>false</SignAssembly>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>


### PR DESCRIPTION
The build sdk sets net462 itself, so every template carrying its own <TargetFramework> was just noise that could drift out of sync with the sdk default. 