### PR TITLE
chore: drop redundant OutputPath from PCF template

### DIFF
--- a/src/Dataverse/templates/pp-pcf/examplesourcename.csproj
+++ b/src/Dataverse/templates/pp-pcf/examplesourcename.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <Name>examplesourcename</Name>
     <ProjectGuid>56daf92d-4098-4de0-9ba5-0fa2f9e3d36b</ProjectGuid>
-    <OutputPath>$(MSBuildThisFileDirectory)out\controls</OutputPath>
     <ProjectType>Pcf</ProjectType>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
TALXIS.DevKit.Build.Dataverse.Pcf.props already defaults `OutputPath` to `$(MSBuildProjectDirectory)\out\controls`, so the scaffolded PCF project doesn't need to declare it itself. Consumers of a PCF project aren't building .NET code at all (webpack/pcf-scripts owns the actual build), so the template shouldn't carry MSBuild property clutter with no function.

Note: `TargetFramework`/`net462` was already dropped from this template on `master` in a prior commit - verified empirically (scratch PCF control build via TALXIS.DevKit.Build.Sdk, Debug+Release) that PCF builds succeed fine relying purely on the SDK's `net472` default; Microsoft.PowerApps.MSBuild.Pcf's own props/targets never reference TargetFramework at all.