### PR TITLE
fix snk key passthrough in pp-plugin and pp-workflow-activity

### DIFF
--- a/src/Dataverse/templates/pp-plugin/.template.scripts/InitializePlugin.ps1
+++ b/src/Dataverse/templates/pp-plugin/.template.scripts/InitializePlugin.ps1
@@ -65,10 +65,33 @@ $companyElement = $csproj.CreateElement("Company", $namespaceUri)
 $companyElement.InnerText = $company
 $propertyGroup.AppendChild($companyElement) | Out-Null
 
-# --- 13. Generate SNK file if it doesn't exist (cross-platform, no sn.exe needed) ---
-$snkPath = $signingKey
-if (-not (Test-Path $snkPath)) {
-    Write-Host "Generating strong name key file: $signingKey"
+# --- 13. Use the provided SNK file, or generate one when no key was passed ---
+# placeholder is split so the template engine does not substitute it here as well
+$placeholder = "signingkeyfilepath" + "example"
+$useProvidedKey = -not [string]::IsNullOrWhiteSpace($signingKey) -and $signingKey -ne $placeholder
+if ($useProvidedKey) {
+    $snkSource = $null
+    if ([System.IO.Path]::IsPathRooted($signingKey)) {
+        if (Test-Path $signingKey) { $snkSource = $signingKey }
+    } else {
+        $dir = (Get-Location).Path
+        while ($dir) {
+            $candidate = Join-Path $dir $signingKey
+            if (Test-Path $candidate) { $snkSource = $candidate; break }
+            $dir = Split-Path $dir -Parent
+        }
+    }
+    if (-not $snkSource) {
+        Write-Error "Signing key file not found: '$signingKey'. Pass a path to an existing .snk file or omit --SigningKeyFilePath to generate one."
+        exit 1
+    }
+    $snkSource = (Resolve-Path $snkSource).Path
+    $snkPath = [System.IO.Path]::GetFileName($snkSource)
+    $snkDestination = Join-Path (Get-Location) $snkPath
+    if ($snkSource -ne $snkDestination) { Copy-Item $snkSource -Destination $snkDestination -Force }
+    Write-Host "Using provided SNK file: $snkSource"
+} else {
+    Write-Host "Generating strong name key file"
     Add-Type -AssemblyName System.Security.Cryptography.Csp -ErrorAction SilentlyContinue
     $csharp = @"
 using System;

--- a/src/Dataverse/templates/pp-workflow-activity/.template.config/template.json
+++ b/src/Dataverse/templates/pp-workflow-activity/.template.config/template.json
@@ -54,6 +54,21 @@
   ],
   "postActions": [
     {
+      "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
+      "args": {
+        "executable": "pwsh",
+        "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/InitializePlugin.ps1\"",
+        "redirectStandardOutput": "false"
+      },
+      "manualInstructions": [
+        {
+          "text": "Initialize the workflow activities project"
+        }
+      ],
+      "continueOnError": false,
+      "description": "Initialize the workflow activities project (assembly signing setup)"
+    },
+    {
       "description": "Add generated project to .sln file",
       "manualInstructions": [
         {
@@ -66,6 +81,21 @@
       "actionId": "D396686C-DE0E-4DE6-906D-291CD29FC5DE",
       "continueOnError": false,
       "primaryOutputIndexes": "0"
+    },
+    {
+      "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
+      "args": {
+        "executable": "pwsh",
+        "args": "-noprofile -executionpolicy bypass -File \"./.template.scripts/Cleanup.ps1\"",
+        "redirectStandardOutput": "false"
+      },
+      "manualInstructions": [
+        {
+          "text": "Removing template files"
+        }
+      ],
+      "continueOnError": false,
+      "description": "Removing template files"
     }
   ]
 }

--- a/src/Dataverse/templates/pp-workflow-activity/.template.scripts/InitializePlugin.ps1
+++ b/src/Dataverse/templates/pp-workflow-activity/.template.scripts/InitializePlugin.ps1
@@ -1,75 +1,51 @@
-# --- Input parameters (templated) ---
+# --- Input parameters ---
 $signingKey = "signingkeyfilepathexample"
 $outputDir = "../SolutionLogicalNameExample"
-$author = "examplepublisher"
-$company = "exampleсompany"
 
-# --- Resolve paths ---
-$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
-$resolvedOutputDir = Resolve-Path -Path $outputDir -ErrorAction SilentlyContinue
-if (-not $resolvedOutputDir) {
-    $resolvedOutputDir = Join-Path (Get-Location) $outputDir
-}
-$resolvedOutputDir = $resolvedOutputDir.ToString()
-$useSigningKey = -not [string]::IsNullOrWhiteSpace($signingKey) -and $signingKey -ne "signingkeyfilepathexample"
+# --- 1. Enter the project directory ---
+cd $outputDir
 
-# --- 1. Initialize project from PAC (plugin scaffold as base) ---
-$pacArgs = @("plugin", "init", "--outputDirectory", $resolvedOutputDir, "--author", $author)
-if ($useSigningKey) {
-    $pacArgs += @("--signing-key-file-path", $signingKey)
-} else {
-    # Explicitly skip signing so PAC CLI does not auto-generate a key
-    $pacArgs += @("--skip-signing")
-}
-pac @pacArgs
-Set-Location $resolvedOutputDir
-
-# --- 2. Drop plugin-specific generated files ---
-@("Plugin1.cs", "PluginBase.cs") | ForEach-Object {
-    Remove-Item $_ -ErrorAction SilentlyContinue
-}
-
-# --- 3. Add workflow activity base class from template temp folder ---
-$workflowBaseSource = Join-Path (Split-Path $scriptRoot -Parent) ".template.temp/WorkflowActivityBase.cs"
-if (Test-Path $workflowBaseSource) {
-    Copy-Item $workflowBaseSource -Destination $resolvedOutputDir -Force
-}
-
-# --- 4. Locate the generated .csproj ---
+# --- 2. Find the .csproj file ---
 $csprojFile = Get-ChildItem -Path . -Filter *.csproj | Select-Object -First 1
 if (-not $csprojFile) {
     Write-Error "Could not find a .csproj file in the current directory."
     exit 1
 }
-$projectName = [System.IO.Path]::GetFileNameWithoutExtension($csprojFile.Name)
 
-# --- 5. Compose workflow-activities csproj (override existing) ---
-$signAssemblyValue = if ($useSigningKey) { "true" } else { "false" }
-$signingKeyLine = if ($useSigningKey) { "    <AssemblyOriginatorKeyFile>$signingKey</AssemblyOriginatorKeyFile>`n" } else { "" }
-$csprojText = @"
-<Project Sdk="TALXIS.DevKit.Build.Sdk/1.7.0">
-  <PropertyGroup>
-    <LangVersion>latest</LangVersion>
-    <SignAssembly>$signAssemblyValue</SignAssembly>
-$signingKeyLine    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
-    <ProjectType>WorkflowActivity</ProjectType>
-    <AssemblyName>$projectName</AssemblyName>
-  </PropertyGroup>
-  <PropertyGroup>
-    <Version>`$(FileVersion)</Version>
-    <Authors>$author</Authors>
-    <Company>$company</Company>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CrmSdk.CoreAssemblies" Version="9.0.2.*" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.*" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CrmSdk.Workflow" Version="*" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.*" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.Activities" />
-  </ItemGroup>
-</Project>
-"@
-Set-Content -Path $csprojFile.FullName -Value $csprojText -Encoding UTF8
+# --- 3. Wire up assembly signing when a key was provided ---
+# placeholder is split so the template engine does not substitute it here as well
+$placeholder = "signingkeyfilepath" + "example"
+$useSigningKey = -not [string]::IsNullOrWhiteSpace($signingKey) -and $signingKey -ne $placeholder
+if ($useSigningKey) {
+    # relative paths are searched from the project directory up through its parents,
+    # because post actions run inside the output directory, not where dotnet new was invoked
+    $snkSource = $null
+    if ([System.IO.Path]::IsPathRooted($signingKey)) {
+        if (Test-Path $signingKey) { $snkSource = $signingKey }
+    } else {
+        $dir = (Get-Location).Path
+        while ($dir) {
+            $candidate = Join-Path $dir $signingKey
+            if (Test-Path $candidate) { $snkSource = $candidate; break }
+            $dir = Split-Path $dir -Parent
+        }
+    }
+    if (-not $snkSource) {
+        Write-Error "Signing key file not found: '$signingKey'. Pass a path to an existing .snk file or omit --SigningKeyFilePath to skip signing."
+        exit 1
+    }
+    $snkSource = (Resolve-Path $snkSource).Path
+    $snkFileName = [System.IO.Path]::GetFileName($snkSource)
+    $snkDestination = Join-Path (Get-Location) $snkFileName
+    if ($snkSource -ne $snkDestination) { Copy-Item $snkSource -Destination $snkDestination -Force }
+    Write-Host "Using provided SNK file: $snkSource"
+
+    [xml]$csproj = Get-Content $csprojFile.FullName -Raw
+    $namespaceUri = $csproj.DocumentElement.NamespaceURI
+    $propertyGroup = $csproj.Project.PropertyGroup | Select-Object -First 1
+    $propertyGroup.SignAssembly = "true"
+    $keyElement = $csproj.CreateElement("AssemblyOriginatorKeyFile", $namespaceUri)
+    $keyElement.InnerText = $snkFileName
+    $propertyGroup.AppendChild($keyElement) | Out-Null
+    $csproj.Save($csprojFile.FullName)
+}

--- a/src/Dataverse/templates/pp-workflow-activity/SolutionLogicalNameExample.csproj
+++ b/src/Dataverse/templates/pp-workflow-activity/SolutionLogicalNameExample.csproj
@@ -10,7 +10,7 @@
   <PropertyGroup>
     <Version>$(FileVersion)</Version>
     <Authors>examplepublisher</Authors>
-    <Company>NETWORG</Company>
+    <Company>exampleсompany</Company>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CrmSdk.CoreAssemblies" Version="9.0.2.*" PrivateAssets="All" />


### PR DESCRIPTION
Passing `--SigningKeyFilePath` broke when snk auto-generation was added: the engine substitutes the value into the placeholder comparison inside the init script too, so pp-plugin always decided no key was passed and generated a fresh one (relative paths also resolved from the output folder, not from where dotnet new ran). In pp-workflow-activity the init script wasn't wired into template.json at all, so the key and `--Company` did nothing.

Now a provided key is found (relative paths are searched up the parent folders), copied into the project and referenced by file name in the csproj. A nonexistent path fails the post action. Without the parameter nothing changes.