### PR TITLE
chore(templates): update pp-plugin-test to FakeXrmEasy v3 on net8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,7 +620,8 @@ describe('My Form Script', () => {
 
 ### Power Platform: Plugin Test Template
 
-- FakeXrmEasy v2 documentation: `https://dynamicsvalue.github.io/fake-xrm-easy-docs/`
+- FakeXrmEasy v3 documentation: `https://dynamicsvalue.github.io/fake-xrm-easy-docs/`
+- The generated test project targets **.NET 8** (FakeXrmEasy 3.x uses the Dataverse Service Client instead of `Microsoft.CrmSdk.CoreAssemblies`). Referencing a .NET Framework plugin project from the .NET 8 test project works via asset target fallback (expect a NU1702 warning).
 
 ### What's included
 - **`FakeXrmEasyTestBase.cs`**: a base class that:
@@ -657,7 +658,7 @@ namespace Plugins.Tests
             var createdId = _service.Create(new Entity("contact"));
 
             // Assert: verify with context storage
-            var created = _context.Data["contact"][createdId];
+            var created = _context.GetEntityById("contact", createdId);
             Assert.IsNotNull(created);
         }
     }

--- a/src/Dataverse/templates/pp-plugin-test/.template.config/template.json
+++ b/src/Dataverse/templates/pp-plugin-test/.template.config/template.json
@@ -4,7 +4,7 @@
   "identity": "TALXIS.DevKit.Templates.Dataverse.PluginTest",
   "name": "Power Platform: Plugin Test",
   "shortName": "pp-plugin-test",
-  "description": "Creates FakeXrmEasyTestBase.cs: abstract test base with _context (IXrmFakedContext) + _service (IOrganizationService), FakeXrmEasy middleware pre-configured (CRUD + message handlers + commercial license). Individual test classes extend this base in a separate test project.",
+  "description": "Creates FakeXrmEasyTestBase.cs: abstract test base with _context (IXrmFakedContext) + _service (IOrganizationService), FakeXrmEasy v3 middleware pre-configured (CRUD + message handlers + commercial license). Individual test classes extend this base in a separate test project.",
   "tags": {
     "language": "C#",
     "type": "item"

--- a/src/Dataverse/templates/pp-plugin-test/.template.scripts/SetUp.ps1
+++ b/src/Dataverse/templates/pp-plugin-test/.template.scripts/SetUp.ps1
@@ -1,6 +1,5 @@
 $folderName  = Split-Path $PWD -Leaf
-dotnet new mstest -f net462
-dotnet add $folderName.csproj package FakeXrmEasy.v9 -v 2.8.0
-dotnet add $folderName.csproj package Microsoft.CrmSdk.CoreAssemblies -v 9.0.2.52
+dotnet new mstest -f net8.0
+dotnet add $folderName.csproj package FakeXrmEasy.v9 -v 3.9.4
 
 Remove-Item "Test1.cs" -Recurse -Force


### PR DESCRIPTION
Bumps pp-plugin-test to FakeXrmEasy.v9 3.9.4. The v3 line targets .NET 8 only, so the generated test project is now net8.0 