### PR TITLE
Expose AppName as a required pp-app-code template parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,23 @@ dotnet new pp-plugin-assembly-step `
 > [!TIP]  
 > You can add component schema validation to your build process using [Power Platform MSBuild targets](https://github.com/TALXIS/tools-devkit-build).
 
+### Code Apps
+Initialize a new code-based Power App project:
+```console
+dotnet new pp-app-code `
+--output "src/CodeApps.WarehousePicking" `
+--DisplayName "Warehouse Picking" `
+--AppName "warehousepicking"
+```
+
+Add a Dataverse table as a data source:
+```console
+dotnet new pp-app-code-data `
+--output "src/CodeApps.WarehousePicking" `
+--ModelSolutionPath "../Solutions.DataModel" `
+--EntityLogicalName "tom_warehouseitem"
+```
+
 ## Tools
 
 ### Power Platform: Script Library template

--- a/src/Dataverse/templates/pp-app-code/.template.config/template.json
+++ b/src/Dataverse/templates/pp-app-code/.template.config/template.json
@@ -6,7 +6,7 @@
   "shortName": "pp-app-code",
   "description": "Creates a code-based Power App project: .csproj (net462, ProjectType=CodeApp) + power.config.json (appId, displayName, environment, build paths). Use when building a .NET code app for Power Platform.",
   "classifications": ["Dataverse", "Power Platform"],
-  "sourceName": "CodeAppExample",
+  "sourceName": "__project-name__",
   "tags": {
 		"type": "project",
 		"language": "XML",
@@ -17,15 +17,22 @@
     "DisplayName": {
       "type": "parameter",
       "datatype": "text",
-      "replaces": "appexampleDisplayName"
+      "replaces": "__display-name__"
     },
     "AppId": {
       "type": "generated",
 			"generator": "guid",
-			"replaces": "appexampleId",
+			"replaces": "__app-id__",
 			"parameters": {
 				"defaultFormat": "d"
 			}
-		}
+		},
+    "AppName": {
+      "type": "parameter",
+      "datatype": "text",
+      "replaces": "__app-name__",
+      "isRequired": true,
+      "description": "Logical name of the app, without the publisher prefix (e.g. warehousepicking). Used as-is for the schema name, the generated .meta.xml file name, and the package folder when this project is referenced from a Solution project. Must be unique among all Code Apps referenced by the same solution."
+    }
   }
 }

--- a/src/Dataverse/templates/pp-app-code/README.md
+++ b/src/Dataverse/templates/pp-app-code/README.md
@@ -22,4 +22,19 @@ Designed for common app scenarios, easy extensibility, and minimal setup.
 - [Tanstack Query](https://tanstack.com/query/latest) - data fetching, state management
 - [Tanstack Table](https://tanstack.com/table/latest) - interactive tables, datagrids
 - [Lucide](https://lucide.dev/) - icons
-  
+
+---
+
+## Parameters
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `DisplayName` | No | Display name shown for the app. |
+| `AppName` | Yes | Logical name of the app, without the publisher prefix (e.g. `warehousepicking`). Used as-is for the schema name, the generated `.meta.xml` file name, and the package folder when this project is referenced from a Solution project. Must be unique among all Code Apps referenced by the same solution. |
+
+Example:
+```console
+dotnet new pp-app-code `
+--output "src/CodeApps.WarehousePicking" `
+--DisplayName "Warehouse Picking" `
+--AppName "warehousepicking"
+```

--- a/src/Dataverse/templates/pp-app-code/__project-name__.csproj
+++ b/src/Dataverse/templates/pp-app-code/__project-name__.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="TALXIS.DevKit.Build.Sdk/1.8.1">
   <PropertyGroup>
-    <AppName>codeappexample</AppName>
+    <AppName>__app-name__</AppName>
     <ProjectType>CodeApp</ProjectType>
   </PropertyGroup>
 </Project>

--- a/src/Dataverse/templates/pp-app-code/power.config.json
+++ b/src/Dataverse/templates/pp-app-code/power.config.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
-  "appId": "appexampleId",
-  "appDisplayName": "appexampleDisplayName",
+  "appId": "__app-id__",
+  "appDisplayName": "__display-name__",
   "region": "prod",
   "environmentId": null,
   "description": "",


### PR DESCRIPTION
## Summary

`AppName` drives the CanvasApp schema name (`<prefix>_<appname>`), the generated `.meta.xml` filename, and the package folder inside a solution, but `pp-app-code` gave no way to set it directly — it was derived verbatim from the lowercased `--output` folder name (e.g. `--output ./CodeApps.Warehouse` → `AppName=codeapps.warehouse`). Consumers following a `Noun.Warehouse`-style folder convention got stuck with a dotted, redundant `AppName` unless they broke that convention, with the only workaround being manual `.csproj` patching after scaffolding.

- Add a required `AppName` template parameter, mirroring `pp-script-library`'s `LibraryName` pattern.
- Change `sourceName` from `"CodeAppExample"` to a dedicated `"__project-name__"` token so output-folder-name substitution can never again collide with a domain parameter (this was the actual root cause: the old `codeappexample` literal in the seed `.csproj` was a differently-cased occurrence of `sourceName` that the templating engine's substitution still caught).
- Normalize this template's other placeholders (`DisplayName`, `AppId`) to the same dunder-token convention already used elsewhere in this repo (`pp-script-library`, `pp-entity`, `pp-environment-variable-definition`).
- Document `AppName` in `pp-app-code/README.md` and add a `pp-app-code`/`pp-app-code-data` usage example to the root `README.md`, matching the style of existing template examples.

Companion PR (generic duplicate-root-component validation, superseding an earlier CodeApp-specific attempt) opened against `platform-metadata`: https://github.com/TALXIS/platform-metadata/pull/75

## Test plan
- [x] Installed a `dotnet` toolchain in this session and actually ran the scaffold: `dotnet new pp-app-code --output ./CodeApps.WarehousePicking --AppName warehousepicking --DisplayName "Warehouse Picking"` produces `CodeApps.WarehousePicking/CodeApps.WarehousePicking.csproj` containing `<AppName>warehousepicking</AppName>`, decoupled from the output folder name, plus a correctly substituted `power.config.json` (`appId`, `appDisplayName`).
- [x] Confirmed omitting `--AppName` now fails fast: `Missing mandatory option(s) for the template 'Power Platform: Code App': '--AppName'.`
- [ ] Existing consumers relying on the old derived-AppName behavior should be aware this is now a required parameter (breaking change for anyone not yet passing `--AppName`).