### PR TITLE
fix(pp-plugin-assembly): resolve TargetFramework dynamically instead of hardcoding net462

### DIFF
--- a/src/Dataverse/templates/pp-plugin-assembly/.template.scripts/GenerateAssembly.cs
+++ b/src/Dataverse/templates/pp-plugin-assembly/.template.scripts/GenerateAssembly.cs
@@ -18,18 +18,58 @@ string resolvedPluginRootPath = Path.IsPathRooted(pluginRootPath)
 string csprojPath = Directory.GetFiles(resolvedPluginRootPath, "*.csproj").FirstOrDefault();
 if (csprojPath == null) throw new Exception("csproj not found");
 string projectDirectory = Path.GetDirectoryName(csprojPath);
-string sdkPath = Path.Combine(projectDirectory, "bin", "Debug", "net462", "Microsoft.Xrm.Sdk.dll"); 
-Assembly.LoadFrom(sdkPath);
 string csprojFileName = Path.GetFileNameWithoutExtension(csprojPath);
 
+// Load the csproj early so we can resolve the *actual* TargetFramework the plugin project
+// builds with. The scaffolded csproj no longer hardcodes <TargetFramework>net462</TargetFramework>
+// (removed in #125) — projects now fall through to TALXIS.DevKit.Build.Sdk's own default,
+// which is net472. Hardcoding "net462" here caused builds targeting net472 (the current
+// default) to fail with a confusing FileNotFoundException. Read it from the csproj instead,
+// defaulting to net472 (the SDK's real fallback) rather than net462 if it's absent.
 XmlDocument csprojDoc = new XmlDocument();
 csprojDoc.Load(csprojPath);
 string assemblyName = csprojDoc.SelectNodes("//Project/PropertyGroup/AssemblyName").Cast<XmlNode>().LastOrDefault()?.InnerText ?? csprojFileName;
 string fileVersion = csprojDoc.SelectNodes("//Project/PropertyGroup/FileVersion").Cast<XmlNode>().LastOrDefault()?.InnerText ?? "1.0.0.0";
+
+const string defaultTargetFramework = "net472";
+string targetFramework = csprojDoc.SelectNodes("//Project/PropertyGroup/TargetFramework").Cast<XmlNode>().LastOrDefault()?.InnerText;
+if (string.IsNullOrWhiteSpace(targetFramework))
+{
+    // Plugin projects are single-TFM in practice, but be defensive: if only <TargetFrameworks>
+    // (plural, multi-target) is present, pick the first entry rather than crashing.
+    string targetFrameworks = csprojDoc.SelectNodes("//Project/PropertyGroup/TargetFrameworks").Cast<XmlNode>().LastOrDefault()?.InnerText;
+    targetFramework = targetFrameworks?.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault();
+}
+if (string.IsNullOrWhiteSpace(targetFramework)) targetFramework = defaultTargetFramework;
+
+// Probe both a plain `dotnet build` output (bin/Debug/<tfm>/*.dll) and a published output
+// (bin/Debug/<tfm>/publish/*.dll). Only a build has necessarily run by the time this script
+// executes (via the transitive ProjectReference build), so publish/ may not exist yet.
+// When publish/ *does* exist, prefer it: TALXIS.DevKit.Build.Sdk's plugin publish pipeline
+// ILRepack-merges the plugin's dependencies into the output assembly, so the published copy
+// is the more complete/authoritative one for reflecting over the plugin's types.
+static string ResolveExistingPath(string buildDir, string publishDir, string fileName, string description, string projectDirectory, string targetFramework)
+{
+    string publishPath = Path.Combine(publishDir, fileName);
+    string buildPath = Path.Combine(buildDir, fileName);
+    if (File.Exists(publishPath)) return publishPath;
+    if (File.Exists(buildPath)) return buildPath;
+    throw new FileNotFoundException(
+        $"Could not find {description} ('{fileName}'). Probed:\n  {buildPath}\n  {publishPath}\n" +
+        $"Ensure the plugin project at '{projectDirectory}' has been built (dotnet build/publish) for TargetFramework '{targetFramework}'.",
+        buildPath);
+}
+
+string buildDir = Path.Combine(projectDirectory, "bin", "Debug", targetFramework);
+string publishDirForSdk = Path.Combine(buildDir, "publish");
+string sdkPath = ResolveExistingPath(buildDir, publishDirForSdk, "Microsoft.Xrm.Sdk.dll", "Microsoft.Xrm.Sdk.dll", projectDirectory, targetFramework);
+Assembly.LoadFrom(sdkPath);
+
 string xmlPath = Path.Combine(outputRoot, "__solution-root-path__", "PluginAssemblies", $"{assemblyName}.dll.data.xml");
 
-string dllPath = Path.Combine(resolvedPluginRootPath, "bin", "Debug", "net462", "publish", $"{assemblyName}.dll");
-if (!File.Exists(dllPath)) throw new FileNotFoundException("Build not found", dllPath);
+string pluginBuildDir = Path.Combine(resolvedPluginRootPath, "bin", "Debug", targetFramework);
+string pluginPublishDir = Path.Combine(pluginBuildDir, "publish");
+string dllPath = ResolveExistingPath(pluginBuildDir, pluginPublishDir, $"{assemblyName}.dll", "plugin assembly", resolvedPluginRootPath, targetFramework);
 
 Assembly pluginAssembly = Assembly.LoadFrom(dllPath);
 byte[] token = pluginAssembly.GetName().GetPublicKeyToken();

--- a/src/Dataverse/templates/pp-plugin-assembly/.template.scripts/GenerateAssembly.cs
+++ b/src/Dataverse/templates/pp-plugin-assembly/.template.scripts/GenerateAssembly.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Xml;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json;
 using System.Collections.Generic;
 
 string pluginRootPath = @"__plugin-project-root__";
@@ -20,34 +22,117 @@ if (csprojPath == null) throw new Exception("csproj not found");
 string projectDirectory = Path.GetDirectoryName(csprojPath);
 string csprojFileName = Path.GetFileNameWithoutExtension(csprojPath);
 
-// Load the csproj early so we can resolve the *actual* TargetFramework the plugin project
-// builds with. The scaffolded csproj no longer hardcodes <TargetFramework>net462</TargetFramework>
-// (removed in #125) — projects now fall through to TALXIS.DevKit.Build.Sdk's own default,
-// which is net472. Hardcoding "net462" here caused builds targeting net472 (the current
-// default) to fail with a confusing FileNotFoundException. Read it from the csproj instead,
-// defaulting to net472 (the SDK's real fallback) rather than net462 if it's absent.
+// Load the csproj early for the few static properties that are safe to read as literal XML
+// (AssemblyName / FileVersion are not subject to SDK-default fallback logic the way
+// TargetFramework and the output path are).
 XmlDocument csprojDoc = new XmlDocument();
 csprojDoc.Load(csprojPath);
 string assemblyName = csprojDoc.SelectNodes("//Project/PropertyGroup/AssemblyName").Cast<XmlNode>().LastOrDefault()?.InnerText ?? csprojFileName;
 string fileVersion = csprojDoc.SelectNodes("//Project/PropertyGroup/FileVersion").Cast<XmlNode>().LastOrDefault()?.InnerText ?? "1.0.0.0";
 
-const string defaultTargetFramework = "net472";
-string targetFramework = csprojDoc.SelectNodes("//Project/PropertyGroup/TargetFramework").Cast<XmlNode>().LastOrDefault()?.InnerText;
-if (string.IsNullOrWhiteSpace(targetFramework))
+// --- Resolve TargetFramework and the real build/publish output directories via MSBuild itself ---
+//
+// Earlier revisions of this script hardcoded "net462", then (#135) fell back to a hardcoded
+// "net472" literal when <TargetFramework> was absent from the csproj — both are re-implementations
+// of TALXIS.DevKit.Build.Sdk's own default-resolution logic, and both break silently the moment
+// that SDK default changes again. Same problem existed for the output *path*: reconstructing
+// bin/<Configuration>/<TargetFramework>/ by string concatenation assumes nobody has customized
+// <OutputPath>, <BaseOutputPath>, or <OutDir>.
+//
+// Instead, ask MSBuild for the actual, fully-resolved values via the .NET SDK's
+// `-getProperty` evaluation switch (SDK 8+; this repo's build agents run SDK 9/10).
+// Verified empirically (see PR discussion): `dotnet build <csproj> -getProperty:X` against a
+// project with no prior bin/obj creates neither directory and does not invoke the Build/
+// CoreCompile targets — it is a property-evaluation-only pass, not a real build, and it's
+// fast (~0.7-0.9s measured here per invocation). `dotnet msbuild` measured the same. This
+// script itself already only runs once per template scaffold invocation (as a post-action,
+// after the plugin project has already been built separately), so there's no nested-build/
+// node-reuse conflict with an in-flight build of the same project.
+static Dictionary<string, string> QueryMSBuildProperties(string csprojPath, params string[] properties)
 {
-    // Plugin projects are single-TFM in practice, but be defensive: if only <TargetFrameworks>
-    // (plural, multi-target) is present, pick the first entry rather than crashing.
-    string targetFrameworks = csprojDoc.SelectNodes("//Project/PropertyGroup/TargetFrameworks").Cast<XmlNode>().LastOrDefault()?.InnerText;
-    targetFramework = targetFrameworks?.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault();
-}
-if (string.IsNullOrWhiteSpace(targetFramework)) targetFramework = defaultTargetFramework;
+    var psi = new ProcessStartInfo("dotnet")
+    {
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+        WorkingDirectory = Path.GetDirectoryName(csprojPath),
+    };
+    psi.ArgumentList.Add("build");
+    psi.ArgumentList.Add(csprojPath);
+    psi.ArgumentList.Add("-nologo");
+    foreach (string property in properties) psi.ArgumentList.Add($"-getProperty:{property}");
 
-// Probe both a plain `dotnet build` output (bin/Debug/<tfm>/*.dll) and a published output
-// (bin/Debug/<tfm>/publish/*.dll). Only a build has necessarily run by the time this script
-// executes (via the transitive ProjectReference build), so publish/ may not exist yet.
-// When publish/ *does* exist, prefer it: TALXIS.DevKit.Build.Sdk's plugin publish pipeline
-// ILRepack-merges the plugin's dependencies into the output assembly, so the published copy
-// is the more complete/authoritative one for reflecting over the plugin's types.
+    using Process proc = Process.Start(psi) ?? throw new Exception("Failed to start 'dotnet build -getProperty' process.");
+    string stdout = proc.StandardOutput.ReadToEnd();
+    string stderr = proc.StandardError.ReadToEnd();
+    proc.WaitForExit();
+
+    if (proc.ExitCode != 0)
+        throw new Exception(
+            $"'dotnet build \"{csprojPath}\" -nologo {string.Join(" ", properties.Select(p => $"-getProperty:{p}"))}' " +
+            $"failed with exit code {proc.ExitCode} while resolving MSBuild properties.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+
+    var result = new Dictionary<string, string>();
+    try
+    {
+        using JsonDocument doc = JsonDocument.Parse(stdout);
+        // Multiple -getProperty switches produce {"Properties": {"Name": "Value", ...}}.
+        // A single -getProperty prints the bare value with no JSON wrapper at all (handled below).
+        if (doc.RootElement.ValueKind == JsonValueKind.Object && doc.RootElement.TryGetProperty("Properties", out JsonElement propsElement))
+        {
+            foreach (string property in properties)
+                result[property] = propsElement.TryGetProperty(property, out JsonElement value) ? value.GetString() ?? "" : "";
+            return result;
+        }
+    }
+    catch (JsonException)
+    {
+        // Fall through to the single-property bare-text case below.
+    }
+
+    if (properties.Length == 1)
+    {
+        result[properties[0]] = stdout.Trim();
+        return result;
+    }
+
+    throw new Exception($"Could not parse MSBuild -getProperty output for '{csprojPath}'.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+}
+
+// MSBuild's -getProperty output for path-valued properties can be relative (relative to the
+// project directory) and can mix '\' and '/' separators (e.g. "bin\\Debug/net472/publish/",
+// because $(OutputPath) is a literal "bin\" combined with a forward-slash-joined TFM segment).
+// Normalize separators, then resolve relative to the project directory if not already rooted.
+static string ResolveMSBuildPath(string rawValue, string projectDirectory)
+{
+    if (string.IsNullOrWhiteSpace(rawValue)) return null;
+    string normalized = rawValue.Replace('\\', '/');
+    return Path.GetFullPath(Path.IsPathRooted(normalized) ? normalized : Path.Combine(projectDirectory, normalized));
+}
+
+Dictionary<string, string> msbuildProps = QueryMSBuildProperties(csprojPath, "TargetFramework", "TargetDir", "PublishDir");
+
+string targetFramework = msbuildProps.GetValueOrDefault("TargetFramework");
+if (string.IsNullOrWhiteSpace(targetFramework))
+    throw new Exception($"MSBuild did not report a TargetFramework for '{csprojPath}'. Raw properties: {string.Join(", ", msbuildProps.Select(kv => $"{kv.Key}={kv.Value}"))}");
+
+// TargetDir is MSBuild's own fully-resolved build output directory (absolute), so it already
+// reflects any <OutputPath>/<BaseOutputPath>/<OutDir> customization instead of us guessing it.
+string buildDir = ResolveMSBuildPath(msbuildProps.GetValueOrDefault("TargetDir"), projectDirectory);
+if (string.IsNullOrWhiteSpace(buildDir))
+    throw new Exception($"MSBuild did not report a TargetDir for '{csprojPath}'.");
+
+// PublishDir is likewise MSBuild's own resolved publish output directory. It's normally
+// TargetDir + "publish/" but ask for it explicitly rather than assume that convention holds.
+string publishDir = ResolveMSBuildPath(msbuildProps.GetValueOrDefault("PublishDir"), projectDirectory);
+if (string.IsNullOrWhiteSpace(publishDir)) publishDir = Path.Combine(buildDir, "publish");
+
+// Probe both the plain build output (TargetDir/*.dll) and the published output
+// (PublishDir/*.dll). Only a build has necessarily run by the time this script executes (via
+// the transitive ProjectReference build), so the publish output may not exist yet. When it
+// *does* exist, prefer it: TALXIS.DevKit.Build.Sdk's plugin publish pipeline ILRepack-merges
+// the plugin's dependencies into the output assembly, so the published copy is the more
+// complete/authoritative one for reflecting over the plugin's types.
 static string ResolveExistingPath(string buildDir, string publishDir, string fileName, string description, string projectDirectory, string targetFramework)
 {
     string publishPath = Path.Combine(publishDir, fileName);
@@ -60,16 +145,12 @@ static string ResolveExistingPath(string buildDir, string publishDir, string fil
         buildPath);
 }
 
-string buildDir = Path.Combine(projectDirectory, "bin", "Debug", targetFramework);
-string publishDirForSdk = Path.Combine(buildDir, "publish");
-string sdkPath = ResolveExistingPath(buildDir, publishDirForSdk, "Microsoft.Xrm.Sdk.dll", "Microsoft.Xrm.Sdk.dll", projectDirectory, targetFramework);
+string sdkPath = ResolveExistingPath(buildDir, publishDir, "Microsoft.Xrm.Sdk.dll", "Microsoft.Xrm.Sdk.dll", projectDirectory, targetFramework);
 Assembly.LoadFrom(sdkPath);
 
 string xmlPath = Path.Combine(outputRoot, "__solution-root-path__", "PluginAssemblies", $"{assemblyName}.dll.data.xml");
 
-string pluginBuildDir = Path.Combine(resolvedPluginRootPath, "bin", "Debug", targetFramework);
-string pluginPublishDir = Path.Combine(pluginBuildDir, "publish");
-string dllPath = ResolveExistingPath(pluginBuildDir, pluginPublishDir, $"{assemblyName}.dll", "plugin assembly", resolvedPluginRootPath, targetFramework);
+string dllPath = ResolveExistingPath(buildDir, publishDir, $"{assemblyName}.dll", "plugin assembly", resolvedPluginRootPath, targetFramework);
 
 Assembly pluginAssembly = Assembly.LoadFrom(dllPath);
 byte[] token = pluginAssembly.GetName().GetPublicKeyToken();

--- a/src/Dataverse/templates/pp-plugin-assembly/.template.scripts/GenerateAssembly.cs
+++ b/src/Dataverse/templates/pp-plugin-assembly/.template.scripts/GenerateAssembly.cs
@@ -5,6 +5,7 @@ using System.Xml;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
+using System.Threading.Tasks;
 using System.Collections.Generic;
 
 string pluginRootPath = @"__plugin-project-root__";
@@ -30,24 +31,21 @@ csprojDoc.Load(csprojPath);
 string assemblyName = csprojDoc.SelectNodes("//Project/PropertyGroup/AssemblyName").Cast<XmlNode>().LastOrDefault()?.InnerText ?? csprojFileName;
 string fileVersion = csprojDoc.SelectNodes("//Project/PropertyGroup/FileVersion").Cast<XmlNode>().LastOrDefault()?.InnerText ?? "1.0.0.0";
 
-// --- Resolve TargetFramework and the real build/publish output directories via MSBuild itself ---
+// --- Resolve TargetFramework and the real build/publish output directories ---
 //
-// Earlier revisions of this script hardcoded "net462", then (#135) fell back to a hardcoded
-// "net472" literal when <TargetFramework> was absent from the csproj — both are re-implementations
-// of TALXIS.DevKit.Build.Sdk's own default-resolution logic, and both break silently the moment
-// that SDK default changes again. Same problem existed for the output *path*: reconstructing
-// bin/<Configuration>/<TargetFramework>/ by string concatenation assumes nobody has customized
-// <OutputPath>, <BaseOutputPath>, or <OutDir>.
+// Preferred: ask MSBuild itself via the .NET SDK's `-getProperty` evaluation switch (SDK 8+).
+// This reports the actual evaluated TargetFramework/TargetDir/PublishDir, including any
+// customized <OutputPath>/<BaseOutputPath>/<OutDir>/<PublishDir> — unlike a hardcoded literal
+// (this script's TargetFramework guess has already gone stale once, net462 -> net472), it
+// can't drift from whatever TALXIS.DevKit.Build.Sdk's default actually resolves to.
+// `-getProperty` is evaluation-only (verified: against a project with no prior bin/obj it
+// creates neither directory and never invokes Build/CoreCompile), so this doesn't perform a
+// second real build of the plugin project.
 //
-// Instead, ask MSBuild for the actual, fully-resolved values via the .NET SDK's
-// `-getProperty` evaluation switch (SDK 8+; this repo's build agents run SDK 9/10).
-// Verified empirically (see PR discussion): `dotnet build <csproj> -getProperty:X` against a
-// project with no prior bin/obj creates neither directory and does not invoke the Build/
-// CoreCompile targets — it is a property-evaluation-only pass, not a real build, and it's
-// fast (~0.7-0.9s measured here per invocation). `dotnet msbuild` measured the same. This
-// script itself already only runs once per template scaffold invocation (as a post-action,
-// after the plugin project has already been built separately), so there's no nested-build/
-// node-reuse conflict with an in-flight build of the same project.
+// Fallback: if the subprocess is unavailable or misbehaves for any reason (older SDK, missing
+// dotnet, timeout), fall back to reading <TargetFramework> literally from the csproj and
+// defaulting to net472 (the SDK's current default), reconstructing bin/Debug/<tfm>/ by
+// convention — so a flaky subprocess never hard-fails the whole scaffold.
 static Dictionary<string, string> QueryMSBuildProperties(string csprojPath, params string[] properties)
 {
     var psi = new ProcessStartInfo("dotnet")
@@ -60,12 +58,26 @@ static Dictionary<string, string> QueryMSBuildProperties(string csprojPath, para
     psi.ArgumentList.Add("build");
     psi.ArgumentList.Add(csprojPath);
     psi.ArgumentList.Add("-nologo");
+    psi.ArgumentList.Add("--no-restore"); // the plugin project was already restored/built transitively before this script ran
+    psi.ArgumentList.Add("-nodeReuse:false"); // this subprocess never runs twice against the same node; don't leave a build-server process behind
     foreach (string property in properties) psi.ArgumentList.Add($"-getProperty:{property}");
 
     using Process proc = Process.Start(psi) ?? throw new Exception("Failed to start 'dotnet build -getProperty' process.");
-    string stdout = proc.StandardOutput.ReadToEnd();
-    string stderr = proc.StandardError.ReadToEnd();
-    proc.WaitForExit();
+
+    // Kick off both reads concurrently before blocking on either: draining stdout and stderr
+    // sequentially (ReadToEnd(), then ReadToEnd()) can deadlock if the child fills the other
+    // pipe's buffer while this code is still blocked on the first one.
+    Task<string> stdoutTask = proc.StandardOutput.ReadToEndAsync();
+    Task<string> stderrTask = proc.StandardError.ReadToEndAsync();
+
+    if (!proc.WaitForExit(TimeSpan.FromSeconds(30)))
+    {
+        try { proc.Kill(entireProcessTree: true); } catch { /* best effort */ }
+        throw new TimeoutException($"'dotnet build -getProperty' timed out after 30s resolving MSBuild properties for '{csprojPath}'.");
+    }
+
+    string stdout = stdoutTask.GetAwaiter().GetResult();
+    string stderr = stderrTask.GetAwaiter().GetResult();
 
     if (proc.ExitCode != 0)
         throw new Exception(
@@ -110,22 +122,47 @@ static string ResolveMSBuildPath(string rawValue, string projectDirectory)
     return Path.GetFullPath(Path.IsPathRooted(normalized) ? normalized : Path.Combine(projectDirectory, normalized));
 }
 
-Dictionary<string, string> msbuildProps = QueryMSBuildProperties(csprojPath, "TargetFramework", "TargetDir", "PublishDir");
+const string defaultTargetFramework = "net472";
 
-string targetFramework = msbuildProps.GetValueOrDefault("TargetFramework");
-if (string.IsNullOrWhiteSpace(targetFramework))
-    throw new Exception($"MSBuild did not report a TargetFramework for '{csprojPath}'. Raw properties: {string.Join(", ", msbuildProps.Select(kv => $"{kv.Key}={kv.Value}"))}");
+string ResolveFallbackTargetFramework()
+{
+    string tfm = csprojDoc.SelectNodes("//Project/PropertyGroup/TargetFramework").Cast<XmlNode>().LastOrDefault()?.InnerText;
+    if (string.IsNullOrWhiteSpace(tfm))
+    {
+        // Plugin projects are single-TFM in practice, but be defensive: if only
+        // <TargetFrameworks> (plural, multi-target) is present, pick the first entry.
+        string tfms = csprojDoc.SelectNodes("//Project/PropertyGroup/TargetFrameworks").Cast<XmlNode>().LastOrDefault()?.InnerText;
+        tfm = tfms?.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault();
+    }
+    return string.IsNullOrWhiteSpace(tfm) ? defaultTargetFramework : tfm;
+}
 
-// TargetDir is MSBuild's own fully-resolved build output directory (absolute), so it already
-// reflects any <OutputPath>/<BaseOutputPath>/<OutDir> customization instead of us guessing it.
-string buildDir = ResolveMSBuildPath(msbuildProps.GetValueOrDefault("TargetDir"), projectDirectory);
-if (string.IsNullOrWhiteSpace(buildDir))
-    throw new Exception($"MSBuild did not report a TargetDir for '{csprojPath}'.");
+string targetFramework;
+string buildDir;
+string publishDir;
+try
+{
+    Dictionary<string, string> msbuildProps = QueryMSBuildProperties(csprojPath, "TargetFramework", "TargetDir", "PublishDir");
 
-// PublishDir is likewise MSBuild's own resolved publish output directory. It's normally
-// TargetDir + "publish/" but ask for it explicitly rather than assume that convention holds.
-string publishDir = ResolveMSBuildPath(msbuildProps.GetValueOrDefault("PublishDir"), projectDirectory);
-if (string.IsNullOrWhiteSpace(publishDir)) publishDir = Path.Combine(buildDir, "publish");
+    targetFramework = msbuildProps.GetValueOrDefault("TargetFramework");
+    // TargetDir is MSBuild's own fully-resolved build output directory (absolute), so it
+    // already reflects any <OutputPath>/<BaseOutputPath>/<OutDir> customization.
+    buildDir = ResolveMSBuildPath(msbuildProps.GetValueOrDefault("TargetDir"), projectDirectory);
+    if (string.IsNullOrWhiteSpace(targetFramework) || string.IsNullOrWhiteSpace(buildDir))
+        throw new Exception($"MSBuild did not report a usable TargetFramework/TargetDir for '{csprojPath}'. Raw properties: {string.Join(", ", msbuildProps.Select(kv => $"{kv.Key}={kv.Value}"))}");
+
+    // PublishDir is likewise MSBuild's own resolved publish output directory. It's normally
+    // TargetDir + "publish/" but ask for it explicitly rather than assume that convention holds.
+    publishDir = ResolveMSBuildPath(msbuildProps.GetValueOrDefault("PublishDir"), projectDirectory);
+    if (string.IsNullOrWhiteSpace(publishDir)) publishDir = Path.Combine(buildDir, "publish");
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"Warning: could not resolve TargetFramework/output paths via MSBuild for '{csprojPath}' ({ex.Message}); falling back to reading the csproj directly with a '{defaultTargetFramework}' default.");
+    targetFramework = ResolveFallbackTargetFramework();
+    buildDir = Path.Combine(projectDirectory, "bin", "Debug", targetFramework);
+    publishDir = Path.Combine(buildDir, "publish");
+}
 
 // Probe both the plain build output (TargetDir/*.dll) and the published output
 // (PublishDir/*.dll). Only a build has necessarily run by the time this script executes (via


### PR DESCRIPTION
## Symptom

`dotnet new pp-plugin-assembly ...` (or `txc workspace component create pp-plugin-assembly ...`) against a scaffolded, built Plugin project fails:

```
Error: Unhandled exception. System.IO.FileNotFoundException: Could not load file or assembly '.../bin/Debug/net462/Microsoft.Xrm.Sdk.dll'. The system cannot find the file specified.
```

Reproduced end-to-end via the TALXIS/alm-lab training lab's checkpoint scripts.

## Root cause

`GenerateAssembly.cs` (the `pp-plugin-assembly` post-action script) hardcoded `"net462"` when probing for `Microsoft.Xrm.Sdk.dll` and the plugin's compiled assembly. #125 removed the explicit `<TargetFramework>net462</TargetFramework>` from scaffolded plugin csprojs, so projects now fall through to `TALXIS.DevKit.Build.Sdk`'s own default (`net472`) — but this script was never updated to match. It also assumed a `bin/Debug/<tfm>/publish/` subfolder always exists, which a plain `dotnet build` doesn't guarantee.

## Fix

- **Primary**: resolve `TargetFramework`/`TargetDir`/`PublishDir` by asking MSBuild directly (`dotnet build <csproj> -getProperty:... -nodeReuse:false --no-restore`, evaluation-only, no real build triggered). This is correct even if the SDK's default TFM changes again, or if `<OutputPath>`/`<OutDir>`/`<PublishDir>` is customized — unlike a hardcoded literal, which already went stale once (net462 → net472).
- The subprocess call reads `stdout`/`stderr` concurrently with a 30s timeout that kills the whole process tree on expiry, avoiding the classic Process-redirection deadlock and guaranteeing no orphaned child process.
- **Fallback**: if that subprocess fails for any reason, falls back to reading `<TargetFramework>` literally from the csproj (defaulting to `net472`) and the conventional `bin/Debug/<tfm>/` path — so a flaky subprocess can't hard-fail the whole scaffold.
- Both the SDK assembly and the plugin's own assembly are probed at `bin/Debug/<tfm>/` and `bin/Debug/<tfm>/publish/`, preferring `publish/` when present. A missing file now throws a clear `FileNotFoundException` listing every path probed and the resolved TFM.

## Verified

- Compiles cleanly (`dotnet run --file GenerateAssembly.cs`), only pre-existing-style nullable warnings.
- Isolated checks of the `-getProperty` subprocess: confirmed JSON output shape for multi-property calls vs. bare text for a single property, confirmed no lingering build-server process is left behind, confirmed evaluation-only (no `bin`/`obj` created).
- **Full end-to-end repro** using the exact alm-lab scenario: scaffolded `Plugins.Warehouse` (`pp-plugin`, no `<TargetFramework>`) with its two real `IPlugin` classes, built it (landed at `bin/Debug/net472/...`, reproducing the original bug), scaffolded `Solutions.Logic` (`pp-solution`), linked the projects, and ran the actual `pp-plugin-assembly` template — succeeded, producing a correct `PluginsWarehouse.dll.data.xml` listing both plugin types with the right public key token. Confirmed via captured stderr that the MSBuild-query path resolved it (not the fallback).
- Edge cases: deleting `publish/` still resolves from the plain build output; renaming away the entire `net472` build output produces the intended clear error naming both probed paths and the correctly-resolved TFM.

Residual risk: genuinely multi-targeted (`<TargetFrameworks>`) plugin projects are untested — believed not to occur in practice for Dataverse plugins.

Companion fix in `talxis/tools-devkit-build` (`PublishOnBuild` default for Plugin projects) addresses a related bug in the same reproduction; both may be needed together for a fully working Dataverse plugin + logic solution build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)