### PR TITLE
Fix GenerateSchema.cs crash on .NET 10 (dotnet run --file / System.Text.Json reflection)

### DIFF
--- a/src/Dataverse/templates/pp-app-code-data/.template.scripts/GenerateSchema.cs
+++ b/src/Dataverse/templates/pp-app-code-data/.template.scripts/GenerateSchema.cs
@@ -1,3 +1,4 @@
+#:property JsonSerializerIsReflectionEnabledByDefault=true
 // Usage: dotnet run --file GenerateSchema.cs -- <SolutionPath> <EntityLogicalName> [OutputPath]
 
 using System;


### PR DESCRIPTION
## Bug

`src/Dataverse/templates/pp-app-code-data/.template.scripts/GenerateSchema.cs` is a .NET 10 "file-based app" (invoked via `dotnet run --file GenerateSchema.cs -- <SolutionPath> <EntityLogicalName> [OutputPath]`, see `Init.ps1` in the same folder). It crashed on every invocation with:

```
Unhandled exception. System.NotSupportedException: JsonTypeInfo metadata for type 'System.String' was not provided by TypeInfoResolver of type 'System.Text.Json.Serialization.Metadata.EmptyJsonTypeInfoResolver'. If using source generation, ensure that all root types passed to the serializer have been annotated with 'JsonSerializableAttribute', along with any types that might be serialized polymorphically.
   at System.Text.Json.ThrowHelper.ThrowNotSupportedException_NoMetadataForType(Type type, IJsonTypeInfoResolver resolver)
   at System.Text.Json.JsonSerializerOptions.GetTypeInfoInternal(Type type, ...)
   at System.Text.Json.Nodes.JsonNode.ConvertFromValue[T](T value, Nullable`1 options)
   at System.Text.Json.Nodes.JsonArray.Add[T](T value)
   at Program.<Main>$(String[] args) in .../GenerateSchema.cs:line 215
```

## Root cause

On the .NET 10 SDK, `dotnet run --file` implicitly generates a project with trimming-safe defaults, which disables reflection-based `System.Text.Json` serialization by default. `JsonArray.Add(someString)` (used at lines ~215-217 and ~319 to build the `enum` / `x-ms-enum-values` / `Color` / `required` JSON arrays) needs that reflection and throws — even for a plain built-in `string` — the compiler even flags these call sites with `IL2026`/`IL3050` warnings.

## Fix

Added the .NET 10 file-based-app inline MSBuild property directive as the very first line of the file:

```
#:property JsonSerializerIsReflectionEnabledByDefault=true
```

This re-enables reflection-based JSON serialization for this single-file app, with no other changes.

## Verification

- Installed the .NET 10.0.302 SDK and reproduced the exact crash/stack trace with a minimal 3-line repro (`new JsonArray().Add("hello")`) run via `dotnet run --file`; confirmed the directive fixes that repro.
- Built a fixture Dataverse solution folder (`Entities/<name>/Entity.xml` with a primary key attribute, a string attribute, and a `state` option-set attribute, matching the exact structure `GenerateSchema.cs` looks up) and ran the **actual, unmodified-otherwise** `GenerateSchema.cs` against it end-to-end via `dotnet run --file`:
  - Before the fix: reproduced the reported crash verbatim, at the same `JsonArray.Add` call site (line 215).
  - After the fix: exits 0, prints `Generated: <path>/tests.Schema.json`, and writes a correctly structured schema JSON with `enum` / `x-ms-enum-values` / `Color` / `required` arrays all populated as expected. Only the pre-existing, expected `IL2026`/`IL3050` trimming warnings remain.

## Other files checked

- `GenerateModel.cs` (same folder, same `dotnet run --file` invocation pattern) does not use `JsonNode`/`JsonArray`/`JsonSerializer` at all — confirmed via inspection, no change needed.
- Searched the whole repo for `"dotnet run --file"` usage (`.ps1`/`.cs`): only `GenerateSchema.cs` and `GenerateModel.cs` match, so no other file needed this fix.

## Residual risk note

All `JsonArray.Add` calls in this file only ever add primitives (`string`, `int`, or a `null` `JsonNode` placeholder for `Color`), so the `IL2026`/`IL3050` trimming warnings are inherent to `JsonArray.Add<T>` and are harmless here — they don't indicate any further runtime risk for this script.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bob7cwVDn4JRJhGBnpPtA5)_