### PR TITLE
Bump templates and test scaffolds from net8.0 to net10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,7 +570,7 @@ dotnet new pp-test-script `
 
 The template creates:
 
-1. **.NET Test Project** - A .NET 8.0 project confiured to run Jest tests via `dotnet test`
+1. **.NET Test Project** - A .NET 10.0 project confiured to run Jest tests via `dotnet test`
 2. **Jest Confiuration** - `jest.config.js` configured for jsdom environment
 3. **Packae Configuration** - `package.json` with Jest dependencies
 4. **jest-core Directory** - Reusable core library containing:

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestMinor"
+  }
+}

--- a/src/Dataverse/TALXIS.DevKit.Templates.Dataverse.csproj
+++ b/src/Dataverse/TALXIS.DevKit.Templates.Dataverse.csproj
@@ -14,7 +14,7 @@
 
 		<!-- Keep package type as 'Template' to show the package as a template package on nuget.org and make your template available in dotnet new search.-->
 		<PackageType>Template</PackageType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<IncludeContentInPack>true</IncludeContentInPack>
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<ContentTargetFolders>templates</ContentTargetFolders>

--- a/src/Dataverse/templates/pp-test-script/examplescripttestprojectname.csproj
+++ b/src/Dataverse/templates/pp-test-script/examplescripttestprojectname.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
 
     <JetsCoreDir>$(MSBuildProjectDirectory)\jest-core</JetsCoreDir>

--- a/src/Dataverse/templates/pp-test-ui-selenium/.template.config/template.json
+++ b/src/Dataverse/templates/pp-test-ui-selenium/.template.config/template.json
@@ -4,7 +4,7 @@
 	"identity": "TALXIS.DevKit.Templates.Dataverse.Test.UI.Selenium",
 	"name": "Power Platform: UI Test (Selenium)",
   "shortName": "pp-test-ui-selenium",
-  "description": "Creates a Reqnroll BDD UI test project: .csproj (.NET 8, TALXIS.TestKit.Bindings) + reqnroll.json (bindingAssemblies: TALXIS.TestKit.Bindings) + appsettings.json (url, browser=Chrome, 1920x1080, deleteTestData=true) + ImplicitUsings.cs + generate-mock-bindings.cs. URL format: https://{org}.crm.dynamics.com/main.aspx?appid={GUID}&pagetype=entitylist&etn={entity}&viewid={GUID}&viewType=1039. Place test data JSON files in Data/ folder for auto-created test records.",
+  "description": "Creates a Reqnroll BDD UI test project: .csproj (.NET 10, TALXIS.TestKit.Bindings) + reqnroll.json (bindingAssemblies: TALXIS.TestKit.Bindings) + appsettings.json (url, browser=Chrome, 1920x1080, deleteTestData=true) + ImplicitUsings.cs + generate-mock-bindings.cs. URL format: https://{org}.crm.dynamics.com/main.aspx?appid={GUID}&pagetype=entitylist&etn={entity}&viewid={GUID}&viewType=1039. Place test data JSON files in Data/ folder for auto-created test records.",
   "tags": {
     "language": "C#",
     "type": "project"

--- a/src/Dataverse/templates/pp-test-ui-selenium/.template.scripts/EnableCucumberSupport.ps1
+++ b/src/Dataverse/templates/pp-test-ui-selenium/.template.scripts/EnableCucumberSupport.ps1
@@ -1,3 +1,3 @@
 Start-Process dotnet -ArgumentList "build" -NoNewWindow -Wait -RedirectStandardOutput ".template.scripts/build_output.txt" -RedirectStandardError ".template.scripts/build_error.txt"
 Start-Sleep -Seconds 10
-Start-Process dotnet -ArgumentList "run --file scripts/generate-mock-bindings.cs -- bin/Debug/net8.0/TALXIS.TestKit.Bindings.dll obj/MockStepBindings.cs" -NoNewWindow -Wait -RedirectStandardOutput ".template.scripts/script_output.txt" -RedirectStandardError ".template.scripts/script_error.txt"
+Start-Process dotnet -ArgumentList "run --file scripts/generate-mock-bindings.cs -- bin/Debug/net10.0/TALXIS.TestKit.Bindings.dll obj/MockStepBindings.cs" -NoNewWindow -Wait -RedirectStandardOutput ".template.scripts/script_output.txt" -RedirectStandardError ".template.scripts/script_error.txt"

--- a/src/Dataverse/templates/pp-test-ui-selenium/TestProjectName.csproj
+++ b/src/Dataverse/templates/pp-test-ui-selenium/TestProjectName.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>PPUITesting</RootNamespace>

--- a/src/Dataverse/templates/pp-test-ui/README.md
+++ b/src/Dataverse/templates/pp-test-ui/README.md
@@ -4,8 +4,8 @@ This project is a generated scaffold for testing a Power Apps model-driven app w
 
 ## Prerequisites
 
-- .NET 8 SDK (LTS)
-- Playwright browser binaries — install with `pwsh bin/Debug/net8.0/playwright.ps1 install chromium` after the first `dotnet build`
+- .NET 10 SDK (LTS)
+- Playwright browser binaries — install with `pwsh bin/Debug/net10.0/playwright.ps1 install chromium` after the first `dotnet build`
 
 ## Project structure
 
@@ -45,7 +45,7 @@ Update `appsettings.json` or environment variables:
 
 ## Reporting
 
-Artifacts are written to `{AppContext.BaseDirectory}/{OutputPath}` — by default this resolves to `bin/<config>/net8.0/TestResults/`.
+Artifacts are written to `{AppContext.BaseDirectory}/{OutputPath}` — by default this resolves to `bin/<config>/net10.0/TestResults/`.
 
 To collect artifacts in a predictable project-relative directory, use:
 

--- a/src/Dataverse/templates/pp-test-ui/Support/Hooks.cs
+++ b/src/Dataverse/templates/pp-test-ui/Support/Hooks.cs
@@ -23,7 +23,7 @@ public sealed class Hooks
     public static async Task BeforeTestRun()
     {
         // Browser binaries must be installed before running tests.
-        // Run `pwsh bin/Debug/net8.0/playwright.ps1 install chromium` or see the README.
+        // Run `pwsh bin/Debug/net10.0/playwright.ps1 install chromium` or see the README.
 
         _playwright = await Playwright.CreateAsync();
         _browser = await _playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions

--- a/src/Dataverse/templates/pp-test-ui/TestProjectName.csproj
+++ b/src/Dataverse/templates/pp-test-ui/TestProjectName.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary

An audit of the repo found no `.NET 10` usage anywhere — the modern (non-Dataverse-Framework-constrained) projects were still on `net8.0`. This bumps them to `net10.0`:

- `src/Dataverse/TALXIS.DevKit.Templates.Dataverse.csproj` — the templates NuGet package itself
- `pp-test-ui/TestProjectName.csproj` (Playwright + Reqnroll UI test template)
- `pp-test-ui-selenium/TestProjectName.csproj` (Selenium + Reqnroll UI test template)
- `pp-test-script/examplescripttestprojectname.csproj` (Jest script-test template)
- Associated docs/scripts referencing `net8.0` output paths (`README.md`, `pp-test-ui/README.md`, `pp-test-ui/Support/Hooks.cs`, `pp-test-ui-selenium/.template.scripts/EnableCucumberSupport.ps1`, `pp-test-ui-selenium/.template.config/template.json`)
- Added a root `global.json` pinning the SDK to `10.0.100` with `rollForward: latestMinor`, so CI's `actions/setup-dotnet@v4` step (which currently has no `dotnet-version` pinned) resolves to .NET 10 automatically

**Not changed:** `pp-plugin`, `pp-workflow-activity`, `pp-package`, and `pp-script-library` templates stay on `net472`/`net462`. Dataverse plugin assemblies and script libraries execute in the Dataverse sandbox, which requires .NET Framework — those are intentional and unrelated to this bump.

**Compatibility:** all package references in the bumped projects (`Microsoft.Extensions.*`, `Microsoft.NET.Test.Sdk`, `Microsoft.Playwright`, `MSTest.*`, `Moq`, `Reqnroll`) target `netstandard2.0`/`net8.0` and are runtime-forward-compatible with .NET 10 — no source or package incompatibilities found.

## Test plan
- [ ] CI build/pack (`main.yml`) succeeds against the pinned .NET 10 SDK
- [ ] `dotnet new pp-test-ui`, `pp-test-ui-selenium`, and `pp-test-script` scaffold projects that restore and build on net10.0
- [ ] `dotnet pack` for `TALXIS.DevKit.Templates.Dataverse.csproj` still produces a valid template package


---
_Generated by [Claude Code](https://claude.ai/code/session_01W2zCcvZhboo96zgiu8hWY4)_