### PR TITLE
fix(pp-plugin-test): stop Cleanup.ps1 removing nonexistent .template.temp

### DIFF
--- a/src/Dataverse/templates/pp-plugin-test/.template.scripts/Cleanup.ps1
+++ b/src/Dataverse/templates/pp-plugin-test/.template.scripts/Cleanup.ps1
@@ -1,2 +1,1 @@
 Remove-Item .template.scripts -Recurse -Force
-Remove-Item .template.temp -Recurse -Force


### PR DESCRIPTION
## Summary

`pp-plugin-test`'s `Cleanup.ps1` post-action unconditionally runs `Remove-Item .template.temp -Recurse -Force`, but `pp-plugin-test` never ships or creates a `.template.temp` directory in the first place. `Remove-Item` on a missing path throws (`-Force` suppresses read-only/hidden-file errors, not "path not found"), the post-action exits non-zero, and `dotnet new` rolls back the entire scaffold.

## Root cause

Several templates (e.g. `pp-plugin-assembly-step`, `pp-form-subgrid`) bundle a physical `.template.temp` folder as template source content, which the `dotnet new` engine copies into the output for use by an intermediate post-action step before it's cleaned up. `pp-plugin-test`'s `Cleanup.ps1` was copy-pasted from one of these templates, but `pp-plugin-test`'s own source tree (`src/Dataverse/templates/pp-plugin-test/`) contains no `.template.temp` folder, and its `SetUp.ps1` never creates one — so the directory genuinely never exists at cleanup time.

## Fix

Drop the `.template.temp` removal from `pp-plugin-test/.template.scripts/Cleanup.ps1`, since this template has nothing to clean up there.

## Workaround being removed downstream

`TALXIS/alm-lab` currently pre-creates `.template.temp` before calling `txc workspace component create pp-plugin-test` as a workaround for this bug (`.lab-scripts/scaffold/14-tests-unit.ps1`). That workaround can be removed once this fix ships.


---
_Generated by [Claude Code](https://claude.ai/code/session_016yczP63MsYKCq7G7SgryGs)_