### PR TITLE
chore(pp-plugin-test): target net10.0 instead of net8.0 for FakeXrmEasy v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,7 +637,8 @@ describe('My Form Script', () => {
 
 ### Power Platform: Plugin Test Template
 
-- FakeXrmEasy v2 documentation: `https://dynamicsvalue.github.io/fake-xrm-easy-docs/`
+- FakeXrmEasy v3 documentation: `https://dynamicsvalue.github.io/fake-xrm-easy-docs/`
+- The generated test project targets **.NET 10** (FakeXrmEasy 3.x uses the Dataverse Service Client instead of `Microsoft.CrmSdk.CoreAssemblies`). Referencing a .NET Framework plugin project from the .NET 10 test project works via asset target fallback (expect a NU1702 warning).
 
 ### What's included
 - **`FakeXrmEasyTestBase.cs`**: a base class that:
@@ -674,7 +675,7 @@ namespace Plugins.Tests
             var createdId = _service.Create(new Entity("contact"));
 
             // Assert: verify with context storage
-            var created = _context.Data["contact"][createdId];
+            var created = _context.GetEntityById("contact", createdId);
             Assert.IsNotNull(created);
         }
     }

--- a/src/Dataverse/templates/pp-plugin-test/.template.config/template.json
+++ b/src/Dataverse/templates/pp-plugin-test/.template.config/template.json
@@ -4,7 +4,7 @@
   "identity": "TALXIS.DevKit.Templates.Dataverse.PluginTest",
   "name": "Power Platform: Plugin Test",
   "shortName": "pp-plugin-test",
-  "description": "Creates FakeXrmEasyTestBase.cs: abstract test base with _context (IXrmFakedContext) + _service (IOrganizationService), FakeXrmEasy middleware pre-configured (CRUD + message handlers + commercial license). Individual test classes extend this base in a separate test project.",
+  "description": "Creates FakeXrmEasyTestBase.cs: abstract test base with _context (IXrmFakedContext) + _service (IOrganizationService), FakeXrmEasy v3 middleware pre-configured (CRUD + message handlers + commercial license). Individual test classes extend this base in a separate test project.",
   "tags": {
     "language": "C#",
     "type": "item"

--- a/src/Dataverse/templates/pp-plugin-test/.template.scripts/SetUp.ps1
+++ b/src/Dataverse/templates/pp-plugin-test/.template.scripts/SetUp.ps1
@@ -1,6 +1,5 @@
 $folderName  = Split-Path $PWD -Leaf
-dotnet new mstest -f net462
-dotnet add $folderName.csproj package FakeXrmEasy.v9 -v 2.8.0
-dotnet add $folderName.csproj package Microsoft.CrmSdk.CoreAssemblies -v 9.0.2.52
+dotnet new mstest -f net10.0
+dotnet add $folderName.csproj package FakeXrmEasy.v9 -v 3.9.4
 
 Remove-Item "Test1.cs" -Recurse -Force


### PR DESCRIPTION
## Summary

Supersedes #133. That PR bumps `pp-plugin-test` to FakeXrmEasy.v9 3.9.4 (the v3 line) and pins the generated test project to net8.0 because the v3 line's package only ships a net8.0-native target. Since #133 was opened, the rest of the repo's test scaffolds were bumped to net10.0 (#137), so this brings `pp-plugin-test` in line instead of leaving it a version behind — same FakeXrmEasy v3 bump, net10.0 instead of net8.0.

- `SetUp.ps1`: `dotnet new mstest -f net10.0` (was net462) + `FakeXrmEasy.v9 -v 3.9.4` (was v2.8.0 + a separate `Microsoft.CrmSdk.CoreAssemblies` package, no longer needed — v3 uses the Dataverse Service Client instead)
- `template.json`: description mentions FakeXrmEasy v3
- `README.md`: doc link/notes updated to v3 and .NET 10, plus the `_context.GetEntityById(...)` API change the v3 line requires (`_context.Data[...]` no longer works)

NuGet reports FakeXrmEasy.v9 3.9.4 as net8.0-native with net9.0/net10.0 as computed-compatible.

## Testing

Scaffolded the template locally end-to-end (.NET 10 SDK + PowerShell):
- `dotnet new pp-plugin-test` → net10.0 mstest project + FakeXrmEasy.v9 3.9.4, restores cleanly, NuGet confirms the package is compatible with net10.0.
- Added the README's sample test (`_context.GetEntityById`) → builds and passes.
- Referenced a net462 plugin project from the net10.0 test project → resolves via asset target fallback with the NU1702 warning the README describes; build and tests still pass.
- Verified this still works cleanly on top of #138's `Cleanup.ps1` fix (no `.template.temp` workaround needed).

One pre-existing, unrelated finding from testing against the [alm-lab](https://github.com/TALXIS/alm-lab) demo: `dotnet add reference` refuses to link a net10.0 (or net8.0 — checked both) test project to a net462 plugin project, so alm-lab's `14-tests-unit.ps1` needed its own fix — see [TALXIS/alm-lab#16](https://github.com/TALXIS/alm-lab/pull/16).


---
_Generated by [Claude Code](https://claude.ai/code/session_01GjoarH3odRA8a4vF6jv9pv)_