### PR TITLE
fix(pp-app-code-data): don't collide transactioncurrencyid with its expanded lookup property

### DIFF
--- a/src/Dataverse/templates/pp-app-code-data/.template.scripts/GenerateModel.cs
+++ b/src/Dataverse/templates/pp-app-code-data/.template.scripts/GenerateModel.cs
@@ -169,6 +169,13 @@ foreach (var attr in attributes)
             Optional = optional
         });
     }
+    else if (attr.Type == "lookup" && !attr.IsCustomField)
+    {
+        // Writable system lookups (e.g. transactioncurrencyid) still get an expanded
+        // {name}?: object pair generated below (Part 2) — use the _value-suffixed raw FK
+        // name here so it doesn't collide with that expanded property of the same name.
+        baseFields.Add(new BaseField { Name = $"_{attr.LogicalName}_value", TypeStr = "string", Optional = optional });
+    }
     else if (attr.Type == "owner")
     {
         // Owner adds ownerid + owneridtype


### PR DESCRIPTION
## Context

Found while dry-running alm-lab's full CP01→CP14 scaffold against the latest published templates (1.24.0), ahead of a workshop tomorrow. Any entity with a Money field (e.g. `WarehouseItem`, `WarehouseTransaction` in alm-lab) gets a system `transactioncurrencyid` lookup that's writable (`ValidForCreateApi`/`ValidForUpdateApi`). The generated code-app model failed to compile:

```
error TS2430: Interface 'Almlab_warehouseitems' incorrectly extends interface 'Almlab_warehouseitemsBase'.
```

## Root cause

`GenerateModel.cs`'s base-interface generator has branches for custom lookups (`@odata.bind`) and `owner` fields, but no branch for a writable **system** (non-custom) lookup. Those fall through to the generic `else` and get emitted with their bare logical name (`transactioncurrencyid?: string`) in the `Base` interface.

Separately, the extended-interface generator (Part 2) unconditionally emits an expanded `{name}?: object` + `_{name}_value?: string` pair for every non-custom lookup — including `transactioncurrencyid`. So `Base` declares `transactioncurrencyid: string` while the extending interface declares `transactioncurrencyid: object` — same property name, incompatible types, which TypeScript rejects.

## Fix

Add a branch for writable system lookups that emits the `_value`-suffixed raw FK name in `Base` (`_transactioncurrencyid_value?: string`) instead of the bare name, matching the naming convention Part 2 already uses for the pairing.

## Testing

Regenerated `Almlab_warehouseitemsModel.ts` and `Almlab_warehousetransactionsModel.ts` against alm-lab's real `Entity.xml` files, before and after the fix:
- Before: `transactioncurrencyid?: string` (Base) + `transactioncurrencyid?: object` (extended) → `tsc --strict` fails with TS2430.
- After: `_transactioncurrencyid_value?: string` (Base) + `transactioncurrencyid?: object` / `_transactioncurrencyid_value?: string` (extended) → `tsc --strict` on both regenerated files passes with zero errors.

Opened as draft — flagging for review, not requesting merge yet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7jqpJTaXnk9YbPkxEXe9F)_