### PR TITLE
chore(pp-app-code): bump @microsoft/power-apps floor to ^1.2.13

### DIFF
--- a/src/Dataverse/templates/pp-app-code/package.json
+++ b/src/Dataverse/templates/pp-app-code/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@microsoft/power-apps": "^1.0.3",
+    "@microsoft/power-apps": "^1.2.13",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",


### PR DESCRIPTION
## What
Bumps the `@microsoft/power-apps` floor in `src/Dataverse/templates/pp-app-code/package.json` from `^1.0.3` to `^1.2.13`.

## Why
A live registry audit against npmjs.org found this pin stale — `@microsoft/power-apps` has moved well past `1.0.3`, and the repo's own `@microsoft/power-apps-vite` dev dependency is already at a newer generation (`^1.0.2`, confirmed current and intentionally left untouched here).

## Verified
- Packed the locally-modified templates repo into a local nupkg (`dotnet pack src/Dataverse/TALXIS.DevKit.Templates.Dataverse.csproj`).
- Installed the local nupkg into the `ghcr.io/talxis/tools-agentbox/image:latest` devcontainer and scaffolded a fresh `pp-app-code` instance (`dotnet new pp-app-code`).
- `npm install` — clean, resolved `@microsoft/power-apps@1.2.13`.
- `npm run build` (`tsc -b && vite build`) — clean, no TypeScript or bundling errors.

## Out of scope
No other files touched. `@microsoft/power-apps-vite` and `FakeXrmEasy.v9` were checked and confirmed already current — not touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V7jqpJTaXnk9YbPkxEXe9F)_