### PR TITLE
chore(pp-test-ui, pp-test-ui-selenium): bump UI test tooling cluster

### DIFF
--- a/src/Dataverse/templates/pp-test-ui-selenium/TestProjectName.csproj
+++ b/src/Dataverse/templates/pp-test-ui-selenium/TestProjectName.csproj
@@ -7,22 +7,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 	  $ReqnrollNugetPackages$
 	  $additionalNugetPackages$
     $fluentAssertionsNugetPackage$
     <PackageReference Include="TALXIS.TestKit.Bindings" Version="1.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-	  <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.10" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+	  <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
+	  <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
+	  <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dataverse/templates/pp-test-ui/TestProjectName.csproj
+++ b/src/Dataverse/templates/pp-test-ui/TestProjectName.csproj
@@ -8,17 +8,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.55.0" />
-    <PackageReference Include="Microsoft.Playwright.MSTest" Version="1.55.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.61.0" />
+    <PackageReference Include="Microsoft.Playwright.MSTest" Version="1.61.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
-    <PackageReference Include="Reqnroll" Version="3.2.0" />
-    <PackageReference Include="Reqnroll.MsTest" Version="3.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
+    <PackageReference Include="Reqnroll" Version="3.3.4" />
+    <PackageReference Include="Reqnroll.MsTest" Version="3.3.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What
Bumps the shared UI-test-tooling version cluster in both:
- `src/Dataverse/templates/pp-test-ui/TestProjectName.csproj`
- `src/Dataverse/templates/pp-test-ui-selenium/TestProjectName.csproj`

Specifically:
- `Microsoft.Extensions.*` (Configuration, Configuration.Binder, Configuration.EnvironmentVariables, Configuration.Abstractions, Configuration.Json, Configuration.UserSecrets, DependencyInjection, Logging.Abstractions, Options, Http, Caching.Memory — whichever are present in each file): `8.0.x` → `10.0.10`.
- `MSTest.TestAdapter` / `MSTest.TestFramework` (pp-test-ui): `3.6.4` → `4.3.3`.
- `Microsoft.NET.Test.Sdk`: `17.12.0` (pp-test-ui) / `17.*` wildcard (pp-test-ui-selenium) → `18.8.1` exact in both.
- `Microsoft.Playwright` / `Microsoft.Playwright.MSTest` (pp-test-ui): `1.55.0` → `1.61.0`.
- `Reqnroll` / `Reqnroll.MsTest` (pp-test-ui): `3.2.0` → `3.3.4`.

`pp-test-ui-selenium`'s own `Reqnroll.*`/`MSTest.*` references are generated via floating wildcards (`2.*`, `3.*`) from `.template.config/template.json` and were left untouched — only the hardcoded pins in the csproj itself were bumped.

## Why
Live NuGet.org audit found the whole cluster multiple majors behind: the `Microsoft.Extensions.*` family was still pinned to .NET 8-era `8.0.x` while the templates themselves already target `net10.0`; `MSTest` 3.x and `Microsoft.NET.Test.Sdk` 17.x are both superseded by current majors; `Microsoft.Playwright` and `Reqnroll` had newer minor/patch releases available.

## Verified
- Packed the locally-modified templates into a local nupkg and installed it into the `ghcr.io/talxis/tools-agentbox/image:latest` devcontainer.
- **pp-test-ui** (Playwright-based): scaffolded a fresh instance, `dotnet build` — clean; installed Playwright's Chromium under `xvfb-run` and ran `dotnet test` — **all 12 sample tests passed**.
- **pp-test-ui-selenium**: build-only, per the no-browser constraint of this sandbox. `pp-test-ui-selenium` is deliberately excluded from the packaged nupkg's `Content Include` in `TALXIS.DevKit.Templates.Dataverse.csproj` (pre-existing, unrelated to this change), so it can't be scaffolded via `dotnet new`. To verify the actual csproj build behavior without relying on that packaging path, I substituted the template's own `.template.config/template.json` macros by hand (default choices: MSTest, FluentAssertions on, no user secrets/Cucumber) and ran `dotnet build` directly against the resulting project — bypassing `dotnet new`/`dotnet new install` entirely to avoid an unrelated interactive-prompt hang risk in this sandbox's templating engine.
  - **Selenium test EXECUTION was not attempted/verified** — no browser or Selenium grid is available in this sandbox.
  - Build result: restore now succeeds cleanly with no `NU1605` package-downgrade conflicts (the *pre-bump* baseline actually fails to restore in this same sandbox, due to `Microsoft.Extensions.Caching.Memory` pulling in a newer transitive `Microsoft.Extensions.{Logging.Abstractions,Options}` than the old `8.0.0` pins allow — this bump fixes that). Build then proceeds to compilation and fails only on a pre-existing, unrelated defect in the external `TALXIS.TestKit.Bindings@1.0.10` NuGet package itself (its packaged `build/` folder is missing the `TALXIS.TestKit.Bindings.MSBuild` subfolder its own `.targets` file references — nothing in this PR touches that package or its version pin).

## Out of scope
No other files touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V7jqpJTaXnk9YbPkxEXe9F)_