### PR TITLE
chore(pp-test-script): bump jest-junit to ^17.0.0

### DIFF
--- a/src/Dataverse/templates/pp-test-script/package.json
+++ b/src/Dataverse/templates/pp-test-script/package.json
@@ -12,6 +12,6 @@
   "devDependencies": {
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
-    "jest-junit": "^16.0.0"
+    "jest-junit": "^17.0.0"
   }
 }


### PR DESCRIPTION
## What
Bumps `jest-junit` in `src/Dataverse/templates/pp-test-script/package.json` from `^16.0.0` to `^17.0.0`.

## Why
Live npm registry audit found `jest-junit` a full major behind current (`17.0.0` is the latest release).

## Verified
- Copied the (version-bumped) `pp-test-script` template content into a scratch directory inside the `ghcr.io/talxis/tools-agentbox/image:latest` devcontainer (the template's `dotnet new` scaffold path runs a `pwsh` post-action to install npm packages, which I avoided invoking directly — see note below).
- Added a minimal smoke test exercising the template's own `jest-core` Xrm mock helpers (the shipped template ships no sample `*.test.js` under `tests/`, only a `tests/utils/loadWebRes.js` helper), since the goal was to exercise the Jest toolchain including `jest-junit` end-to-end.
- `npm install` — clean, resolved `jest-junit@17.0.0`.
- `npm test` (`jest --runInBand`) — 1/1 passed.

## Out of scope
No other files touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V7jqpJTaXnk9YbPkxEXe9F)_