### PR TITLE
chore(pp-pcf): version-pin cleanup (globals, typescript, @types/node, eslint-plugin-power-apps)

### DIFF
--- a/src/Dataverse/templates/pp-pcf/package.json
+++ b/src/Dataverse/templates/pp-pcf/package.json
@@ -16,14 +16,14 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
-    "@microsoft/eslint-plugin-power-apps": "^0.2.51",
-    "@types/node": "^18.19.54",
+    "@microsoft/eslint-plugin-power-apps": "^0.5.1",
+    "@types/node": "^24.6.0",
     "@types/powerapps-component-framework": "^1.3.15",
     "eslint-plugin-promise": "^7.1.0",
-    "globals": "15.13.0",
+    "globals": "^17.9.0",
     "pcf-scripts": "^1",
     "pcf-start": "^1",
-    "typescript": "^4.9.5",
+    "typescript": "^5.0.0",
     "typescript-eslint": "^8.18.1"
   }
 }


### PR DESCRIPTION
## What
Cleans up four stale/inconsistent version pins in `src/Dataverse/templates/pp-pcf/package.json`:
- `globals`: exact pin `15.13.0` → caret range `^17.9.0` (latest major, and matches the caret-range convention other templates use instead of an exact pin).
- `typescript`: `^4.9.5` → `^5.0.0`, aligning with `pp-script-library`'s own `typescript: ^5.0.0` pin instead of staying a major behind it.
- `@types/node`: `^18.19.54` → `^24.6.0`, matching `pp-app-code`'s pin for consistency across templates.
- `@microsoft/eslint-plugin-power-apps`: `^0.2.51` → `^0.5.1` (latest).

## Why
Live npm registry audit found all four stale relative to npmjs.org, and `typescript`/`@types/node` were also inconsistent with sibling templates in this same repo (`pp-script-library`, `pp-app-code`).

Before bumping `@types/node`, checked whether PCF specifically needs an older Node: `pcf-scripts` and `pcf-start`'s published `engines` both declare `node >= 20` with no upper bound, and `pcf-scripts`' `peerDependencies.typescript` is `^4.0.0 || ^5.0.0` — so both the TypeScript major bump and the newer `@types/node` are compatible.

## Verified
- Packed the locally-modified templates repo into a local nupkg and installed it into the `ghcr.io/talxis/tools-agentbox/image:latest` devcontainer.
- Scaffolded a fresh `pp-pcf` instance (`dotnet new pp-pcf --Name TestPcf --Namespace TestNs`).
- `npm install` — clean; resolved versions confirmed: `globals@17.9.0`, `typescript@5.9.3`, `@types/node@24.13.3`, `@microsoft/eslint-plugin-power-apps@0.5.1`.
- `npm run build` (`pcf-scripts build`) — clean, manifest/design types generated, ESLint pass, webpack bundle succeeded.
- `npm run lint` (`pcf-scripts lint`) — clean.

## Out of scope
No other files touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V7jqpJTaXnk9YbPkxEXe9F)_