### PR TITLE
fix(pp-test-ui, pp-test-ui-selenium): gitignore Reqnroll's telemetry marker file

### DIFF
--- a/src/Dataverse/templates/pp-test-ui-selenium/.gitignore
+++ b/src/Dataverse/templates/pp-test-ui-selenium/.gitignore
@@ -399,3 +399,9 @@ FodyWeavers.xsd
 
 # Reqnroll auto-generated code-behind files
 *.feature.cs
+
+# Reqnroll local anonymous-telemetry marker (Reqnroll/userid) — always written to disk
+# on first build regardless of REQNROLL_TELEMETRY_ENABLED (that variable only gates the
+# outbound network send, not local id-file creation — confirmed against Reqnroll's own
+# AnalyticsEventProvider/AnalyticsTransmitter source), so .gitignore is the only reliable fix.
+Reqnroll/

--- a/src/Dataverse/templates/pp-test-ui-selenium/TestProjectName.csproj
+++ b/src/Dataverse/templates/pp-test-ui-selenium/TestProjectName.csproj
@@ -39,4 +39,35 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
+  <!--
+    Reqnroll fires anonymous usage telemetry (and persists a random-GUID marker file,
+    Reqnroll/userid) the first time its MSBuild code-behind generator runs against this
+    project. There is no reqnroll.json / MSBuild-property equivalent for opting out —
+    Reqnroll's generator only reads the REQNROLL_TELEMETRY_ENABLED environment variable
+    (see Reqnroll/Analytics/EnvironmentReqnrollTelemetryChecker.cs upstream). Setting it
+    here, baked into the project, means every consumer of this template is opted out by
+    default regardless of how the project gets built (a lab/CI script, `dotnet build`
+    run by hand, an IDE build) — no caller has to remember to export the variable.
+    The inline task runs in-process and sets a real OS environment variable on the
+    current MSBuild process, which is inherited by the (possibly out-of-process) Reqnroll
+    generation task spawned afterward.
+  -->
+  <UsingTask
+    TaskName="DisableReqnrollTelemetryTask"
+    TaskFactory="RoslynCodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <Task>
+      <Using Namespace="System" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+        Environment.SetEnvironmentVariable("REQNROLL_TELEMETRY_ENABLED", "0");
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <Target Name="DisableReqnrollTelemetry" BeforeTargets="ProcessReqnrollFeatureFilesInProject">
+    <DisableReqnrollTelemetryTask />
+  </Target>
 </Project>

--- a/src/Dataverse/templates/pp-test-ui-selenium/TestProjectName.csproj
+++ b/src/Dataverse/templates/pp-test-ui-selenium/TestProjectName.csproj
@@ -40,34 +40,4 @@
     </None>
   </ItemGroup>
 
-  <!--
-    Reqnroll fires anonymous usage telemetry (and persists a random-GUID marker file,
-    Reqnroll/userid) the first time its MSBuild code-behind generator runs against this
-    project. There is no reqnroll.json / MSBuild-property equivalent for opting out —
-    Reqnroll's generator only reads the REQNROLL_TELEMETRY_ENABLED environment variable
-    (see Reqnroll/Analytics/EnvironmentReqnrollTelemetryChecker.cs upstream). Setting it
-    here, baked into the project, means every consumer of this template is opted out by
-    default regardless of how the project gets built (a lab/CI script, `dotnet build`
-    run by hand, an IDE build) — no caller has to remember to export the variable.
-    The inline task runs in-process and sets a real OS environment variable on the
-    current MSBuild process, which is inherited by the (possibly out-of-process) Reqnroll
-    generation task spawned afterward.
-  -->
-  <UsingTask
-    TaskName="DisableReqnrollTelemetryTask"
-    TaskFactory="RoslynCodeTaskFactory"
-    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
-    <Task>
-      <Using Namespace="System" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-        Environment.SetEnvironmentVariable("REQNROLL_TELEMETRY_ENABLED", "0");
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
-  <Target Name="DisableReqnrollTelemetry" BeforeTargets="ProcessReqnrollFeatureFilesInProject">
-    <DisableReqnrollTelemetryTask />
-  </Target>
 </Project>

--- a/src/Dataverse/templates/pp-test-ui/.gitignore
+++ b/src/Dataverse/templates/pp-test-ui/.gitignore
@@ -16,6 +16,10 @@ TestResults/
 
 # Reqnroll/SpecFlow generated files
 *.feature.cs
+# Reqnroll's local anonymous-telemetry marker (Reqnroll/userid), always written to disk on
+# first build regardless of REQNROLL_TELEMETRY_ENABLED — that variable only gates the
+# outbound network send, not local id-file creation.
+Reqnroll/
 
 # User-specific files
 *.user

--- a/src/Dataverse/templates/pp-test-ui/TestProjectName.csproj
+++ b/src/Dataverse/templates/pp-test-ui/TestProjectName.csproj
@@ -33,4 +33,35 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
+  <!--
+    Reqnroll fires anonymous usage telemetry (and persists a random-GUID marker file,
+    Reqnroll/userid) the first time its MSBuild code-behind generator runs against this
+    project. There is no reqnroll.json / MSBuild-property equivalent for opting out —
+    Reqnroll's generator only reads the REQNROLL_TELEMETRY_ENABLED environment variable
+    (see Reqnroll/Analytics/EnvironmentReqnrollTelemetryChecker.cs upstream). Setting it
+    here, baked into the project, means every consumer of this template is opted out by
+    default regardless of how the project gets built (a lab/CI script, `dotnet build`
+    run by hand, an IDE build) — no caller has to remember to export the variable.
+    The inline task runs in-process and sets a real OS environment variable on the
+    current MSBuild process, which is inherited by the (possibly out-of-process) Reqnroll
+    generation task spawned afterward.
+  -->
+  <UsingTask
+    TaskName="DisableReqnrollTelemetryTask"
+    TaskFactory="RoslynCodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <Task>
+      <Using Namespace="System" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+        Environment.SetEnvironmentVariable("REQNROLL_TELEMETRY_ENABLED", "0");
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <Target Name="DisableReqnrollTelemetry" BeforeTargets="ProcessReqnrollFeatureFilesInProject">
+    <DisableReqnrollTelemetryTask />
+  </Target>
 </Project>

--- a/src/Dataverse/templates/pp-test-ui/TestProjectName.csproj
+++ b/src/Dataverse/templates/pp-test-ui/TestProjectName.csproj
@@ -34,34 +34,4 @@
     </None>
   </ItemGroup>
 
-  <!--
-    Reqnroll fires anonymous usage telemetry (and persists a random-GUID marker file,
-    Reqnroll/userid) the first time its MSBuild code-behind generator runs against this
-    project. There is no reqnroll.json / MSBuild-property equivalent for opting out —
-    Reqnroll's generator only reads the REQNROLL_TELEMETRY_ENABLED environment variable
-    (see Reqnroll/Analytics/EnvironmentReqnrollTelemetryChecker.cs upstream). Setting it
-    here, baked into the project, means every consumer of this template is opted out by
-    default regardless of how the project gets built (a lab/CI script, `dotnet build`
-    run by hand, an IDE build) — no caller has to remember to export the variable.
-    The inline task runs in-process and sets a real OS environment variable on the
-    current MSBuild process, which is inherited by the (possibly out-of-process) Reqnroll
-    generation task spawned afterward.
-  -->
-  <UsingTask
-    TaskName="DisableReqnrollTelemetryTask"
-    TaskFactory="RoslynCodeTaskFactory"
-    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
-    <Task>
-      <Using Namespace="System" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-        Environment.SetEnvironmentVariable("REQNROLL_TELEMETRY_ENABLED", "0");
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
-  <Target Name="DisableReqnrollTelemetry" BeforeTargets="ProcessReqnrollFeatureFilesInProject">
-    <DisableReqnrollTelemetryTask />
-  </Target>
 </Project>


### PR DESCRIPTION
## Context

Reqnroll (the BDD test framework used by `pp-test-ui`, and pulled in transitively by `pp-test-ui-selenium`) writes a local anonymous-id marker file, `Reqnroll/userid`, the first time its codegen runs against a project with a `.feature` file. It got committed accidentally in an alm-lab dry run since nothing ignored it.

## What changed since this PR was opened

The original approach here tried to disable the write by setting `REQNROLL_TELEMETRY_ENABLED=0` via an inline MSBuild task before Reqnroll's codegen target ran. **That doesn't work, on any platform**, confirmed two ways:

1. Directly against Reqnroll's own source (`AnalyticsEventProvider.cs`, `AnalyticsTransmitter.cs`): `userUniqueIdStore.GetUserId()` is called unconditionally to build every analytics event, before the enabled/disabled check is ever consulted. That check (`EnvironmentReqnrollTelemetryChecker`) only gates whether the resulting event is transmitted over the network — not whether the local id file gets written.
2. Empirically: rebuilt a fresh scaffold with `REQNROLL_TELEMETRY_ENABLED=0` set as a real OS environment variable *before* `dotnet build` even started (the most bulletproof possible test — no MSBuild timing/node-reuse ambiguity) — `Reqnroll/userid` still got created.

So no environment variable, regardless of how or when it's set, can prevent the local file from being created. The inline-task/env-var mechanism has been removed.

## The actual fix

Since the file's local creation can't be prevented, gitignore it instead — which is the only thing that actually matters (a locally-created, harmless, no-PII, random-GUID marker file isn't a problem; that file ending up *tracked in a consumer's git repo* is). Both `pp-test-ui` and `pp-test-ui-selenium` already ship their own `.gitignore` in the scaffolded output, each with an existing Reqnroll-related section — this is a one-line addition per template (`Reqnroll/`) rather than a new mechanism, so every future project scaffolded from either template gets it by default.

## Testing

Packed the modified `pp-test-ui` template, installed it fresh in a clean `ghcr.io/talxis/tools-agentbox/image` container, scaffolded a project, added a real `.feature` file, ran `dotnet build` (succeeds clean), then `git init && git add -A` — `Reqnroll/userid` is created on disk but is **not** staged by git, confirming the fix.