### PR TITLE
fix(pp-plugin-test): namespace FakeXrmEasyTestBase.cs via templated sourceName

### DIFF
--- a/src/Dataverse/templates/pp-plugin-test/.template.config/template.json
+++ b/src/Dataverse/templates/pp-plugin-test/.template.config/template.json
@@ -9,7 +9,7 @@
     "language": "C#",
     "type": "item"
   },
-  "sourceName": "ExamplePluginTestProjectName",
+  "sourceName": "__ExamplePluginTestProjectName__",
   "preferNameDirectory": true,
   "postActions": [
     {

--- a/src/Dataverse/templates/pp-plugin-test/.template.config/template.json
+++ b/src/Dataverse/templates/pp-plugin-test/.template.config/template.json
@@ -9,7 +9,7 @@
     "language": "C#",
     "type": "item"
   },
-  "sourceName": "exampleplugintestprojectname",
+  "sourceName": "ExamplePluginTestProjectName",
   "preferNameDirectory": true,
   "postActions": [
     {

--- a/src/Dataverse/templates/pp-plugin-test/FakeXrmEasyTestBase.cs
+++ b/src/Dataverse/templates/pp-plugin-test/FakeXrmEasyTestBase.cs
@@ -8,7 +8,7 @@ using FakeXrmEasy.Middleware.Messages;
 using FakeXrmEasy.Abstractions.Plugins;
 using FakeXrmEasy.Plugins;
 
-namespace ExamplePluginTestProjectName
+namespace __ExamplePluginTestProjectName__
 {
     public abstract class FakeXrmEasyTestBase
     {

--- a/src/Dataverse/templates/pp-plugin-test/FakeXrmEasyTestBase.cs
+++ b/src/Dataverse/templates/pp-plugin-test/FakeXrmEasyTestBase.cs
@@ -8,7 +8,7 @@ using FakeXrmEasy.Middleware.Messages;
 using FakeXrmEasy.Abstractions.Plugins;
 using FakeXrmEasy.Plugins;
 
-namespace Plugins.Tests
+namespace ExamplePluginTestProjectName
 {
     public abstract class FakeXrmEasyTestBase
     {


### PR DESCRIPTION
## Summary
- `pp-plugin-test`'s `FakeXrmEasyTestBase.cs` hardcodes `namespace Plugins.Tests` as literal text. Its own `template.json` declares `"sourceName": "exampleplugintestprojectname"`, but that token never appears anywhere in the template's content — so it's dead config, and the base class's namespace never tracks the output folder/project name at scaffold time, unlike every other template in this package (e.g. `pp-plugin`'s `PluginBase.cs`, which correctly uses its `SolutionLogicalNameExample` sourceName token in its `namespace` declaration).
- Consumers who scaffold `pp-plugin-test` into a differently-named folder than `Plugins.Tests` (e.g. `Tests.Plugins`, following a `Tests.*` project-naming convention) end up with test classes that can't resolve `FakeXrmEasyTestBase` (`CS0246`), because their own namespace won't match the template's fixed one.
- Fix: give `pp-plugin-test` a proper PascalCase `sourceName` (`ExamplePluginTestProjectName`, matching the `SolutionLogicalNameExample` convention) and use that same token in `FakeXrmEasyTestBase.cs`'s `namespace` declaration, so dotnet-new's substitution correctly derives the namespace from the scaffolded output folder/name — consistent with the rest of the package.

## Testing
- Installed the modified template locally (`dotnet new install .`) and scaffolded `pp-plugin-test --output Tests.Plugins` — `FakeXrmEasyTestBase.cs` now correctly emits `namespace Tests.Plugins`.
- Added a project reference to a `net472` plugin project and a test class declared `namespace Tests.Plugins` (no extra `using` needed) — `dotnet build`/`dotnet test` succeed, tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_014i8SSGCDJR1wvfi555UdNz)_